### PR TITLE
fix: add missing SPDX license header to config/src/state.rs

### DIFF
--- a/config/src/state.rs
+++ b/config/src/state.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
 use cosmic_config::{Config, CosmicConfigEntry, cosmic_config_derive::CosmicConfigEntry};
 use derive_setters::Setters;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Summary

- Add missing `// SPDX-License-Identifier: MPL-2.0` header to `config/src/state.rs`
- This was the only source file (1 of 18) without the required SPDX header

## Test plan

- [ ] Build succeeds (`just`)

🤖 Generated with [Claude Code](https://claude.ai/code)