### PR TITLE
perf(video): optimize wallpaper frame delivery

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -174,6 +174,9 @@ pub struct VideoConfig {
     /// Enable hardware acceleration (default: true)
     #[serde(default = "default_hw_accel")]
     pub hw_accel: bool,
+    /// Optional target frames per second (default: 60)
+    #[serde(default)]
+    pub fps_limit: Option<u32>,
 }
 
 fn default_loop_playback() -> bool {
@@ -198,6 +201,12 @@ impl VideoConfig {
             1.0
         }
     }
+
+    /// Returns fps_limit clamped to a safe range (1..=240), defaulting to 60 FPS.
+    #[must_use]
+    pub fn target_fps(&self) -> u32 {
+        self.fps_limit.unwrap_or(60).clamp(1, 240)
+    }
 }
 
 impl Default for VideoConfig {
@@ -207,6 +216,7 @@ impl Default for VideoConfig {
             loop_playback: true,
             playback_speed: 1.0,
             hw_accel: true,
+            fps_limit: None,
         }
     }
 }
@@ -413,7 +423,8 @@ impl Config {
         context: &Context,
         entry: Entry,
     ) -> Result<(), cosmic_config::Error> {
-        let output_key = if entry.output == "all" {
+        let is_default_entry = entry.output == "all";
+        let output_key = if is_default_entry {
             entry.output.clone()
         } else {
             self.outputs.insert(entry.output.clone());
@@ -428,6 +439,10 @@ impl Config {
             *old = entry;
         } else if entry.output != "all" {
             self.backgrounds.push(entry);
+        }
+
+        if is_default_entry {
+            return Ok(());
         }
 
         let new_value = self.outputs.iter().cloned().collect::<Vec<_>>();

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -327,6 +327,8 @@ pub enum SamplingMethod {
 pub enum ScalingMode {
     // Fit the image and fill the rest of the area with the given RGB color
     Fit([f32; 3]),
+    /// Fit the image and fill the rest of the area with a blurred cover-scaled copy
+    FitBlur,
     /// Stretch the image ignoring any aspect ratio to fit the area
     Stretch,
     /// Zoom the image so that it fill the whole area

--- a/cosmic-ext-bg-settings/src/app.rs
+++ b/cosmic-ext-bg-settings/src/app.rs
@@ -149,6 +149,9 @@ impl Application for App {
             Message::VideoHwAccelChanged(hw_accel) => {
                 self.wallpaper_page.video_hw_accel = hw_accel;
             }
+            Message::VideoFpsChanged(fps) => {
+                self.wallpaper_page.video_fps = fps;
+            }
             Message::AnimatedFpsChanged(fps) => {
                 self.wallpaper_page.animated_fps = fps;
             }

--- a/cosmic-ext-bg-settings/src/message.rs
+++ b/cosmic-ext-bg-settings/src/message.rs
@@ -88,6 +88,9 @@ pub enum Message {
     /// Video hardware acceleration changed
     VideoHwAccelChanged(bool),
 
+    /// Video FPS limit changed
+    VideoFpsChanged(Option<u32>),
+
     /// Animated image FPS limit changed
     AnimatedFpsChanged(Option<u32>),
 

--- a/cosmic-ext-bg-settings/src/pages/wallpaper.rs
+++ b/cosmic-ext-bg-settings/src/pages/wallpaper.rs
@@ -25,7 +25,7 @@ static SOURCE_TYPE_NAMES: &[&str] = &[
 ];
 
 /// Scaling mode dropdown options
-static SCALING_MODE_NAMES: &[&str] = &["Zoom (fill)", "Fit (letterbox)", "Stretch"];
+static SCALING_MODE_NAMES: &[&str] = &["Zoom (fill)", "Fit (letterbox)", "Stretch", "Fit blur"];
 
 /// Shader preset dropdown options
 static SHADER_PRESET_NAMES: &[&str] = &["Plasma", "Waves", "Gradient"];
@@ -132,6 +132,7 @@ impl WallpaperPage {
             ScalingMode::Zoom => 0,
             ScalingMode::Fit(_) => 1,
             ScalingMode::Stretch => 2,
+            ScalingMode::FitBlur => 3,
         };
 
         match &entry.source {
@@ -451,6 +452,7 @@ impl WallpaperPage {
                     0 => ScalingMode::Zoom,
                     1 => ScalingMode::Fit([0.0, 0.0, 0.0]),
                     2 => ScalingMode::Stretch,
+                    3 => ScalingMode::FitBlur,
                     _ => ScalingMode::Zoom,
                 };
                 Message::ScalingModeChanged(mode)

--- a/cosmic-ext-bg-settings/src/pages/wallpaper.rs
+++ b/cosmic-ext-bg-settings/src/pages/wallpaper.rs
@@ -49,6 +49,8 @@ pub struct WallpaperPage {
     pub video_speed: f64,
     /// Video hardware acceleration
     pub video_hw_accel: bool,
+    /// Video FPS limit
+    pub video_fps: Option<u32>,
     /// Animated FPS limit
     pub animated_fps: Option<u32>,
     /// Animated loop count
@@ -90,6 +92,7 @@ impl Default for WallpaperPage {
             video_loop: true,
             video_speed: 1.0,
             video_hw_accel: true,
+            video_fps: None,
             animated_fps: None,
             animated_loop_count: None,
             shader_fps: 30,
@@ -144,6 +147,7 @@ impl WallpaperPage {
                 self.video_loop = config.loop_playback;
                 self.video_speed = config.playback_speed;
                 self.video_hw_accel = config.hw_accel;
+                self.video_fps = config.fps_limit.map(|fps| fps.clamp(1, 240));
             }
             Source::Animated(config) => {
                 self.source_type = SourceType::Animated;
@@ -201,6 +205,7 @@ impl WallpaperPage {
                 loop_playback: self.video_loop,
                 playback_speed: self.video_speed,
                 hw_accel: self.video_hw_accel,
+                fps_limit: self.video_fps,
             }),
             SourceType::Animated => Source::Animated(AnimatedConfig {
                 path: self.selected_path.clone().unwrap_or_default(),
@@ -358,6 +363,21 @@ impl WallpaperPage {
                 })
                 .width(Length::Fixed(80.0));
 
+            let fps_input = text_input(
+                "FPS",
+                self.video_fps.map(|f| f.to_string()).unwrap_or_default(),
+            )
+            .on_input(|s| {
+                if s.is_empty() {
+                    Message::VideoFpsChanged(None)
+                } else {
+                    s.parse::<u32>()
+                        .map(|v| Message::VideoFpsChanged(Some(v.clamp(1, 240))))
+                        .unwrap_or(Message::None)
+                }
+            })
+            .width(Length::Fixed(80.0));
+
             column()
                 .spacing(8)
                 .push(
@@ -367,6 +387,7 @@ impl WallpaperPage {
                         .push(toggler(self.video_loop).on_toggle(Message::VideoLoopChanged)),
                 )
                 .push(row().spacing(8).push(text::body("Speed:")).push(speed_input))
+                .push(row().spacing(8).push(text::body("FPS Limit:")).push(fps_input))
                 .push(
                     row()
                         .spacing(8)

--- a/src/animated.rs
+++ b/src/animated.rs
@@ -320,6 +320,7 @@ impl WallpaperSource for AnimatedSource {
         Ok(Frame {
             payload: FramePayload::Image(Arc::new(frame.image.clone())),
             timestamp: Instant::now(),
+            is_placeholder: false,
         })
     }
 

--- a/src/animated.rs
+++ b/src/animated.rs
@@ -5,7 +5,7 @@
 //! This module provides frame-by-frame playback of animated images,
 //! respecting per-frame delay timings for smooth animation.
 
-use crate::source::{Frame, SourceError, WallpaperSource};
+use crate::source::{Frame, FramePayload, SourceError, WallpaperSource};
 use cosmic_ext_bg_config::AnimatedConfig;
 use image::{codecs::gif::GifDecoder, AnimationDecoder, DynamicImage};
 use std::{
@@ -13,6 +13,7 @@ use std::{
     fs::File,
     io::BufReader,
     path::PathBuf,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -317,7 +318,7 @@ impl WallpaperSource for AnimatedSource {
             .ok_or_else(|| decode_error("No frames available", ""))?;
 
         Ok(Frame {
-            image: frame.image.clone(),
+            payload: FramePayload::Image(Arc::new(frame.image.clone())),
             timestamp: Instant::now(),
         })
     }

--- a/src/bin/cosmic-bg-ctl.rs
+++ b/src/bin/cosmic-bg-ctl.rs
@@ -57,6 +57,9 @@ enum Commands {
         /// Disable hardware acceleration
         #[arg(long)]
         no_hw_accel: bool,
+        /// Target FPS limit (default: 60)
+        #[arg(long)]
+        fps: Option<u32>,
     },
 
     /// Set an animated image wallpaper (GIF, WebP, APNG)
@@ -162,7 +165,8 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             r#loop,
             speed,
             no_hw_accel,
-        } => cmd_video(&context, path, output, r#loop, speed, no_hw_accel),
+            fps,
+        } => cmd_video(&context, path, output, r#loop, speed, no_hw_accel, fps),
         Commands::Animated {
             path,
             output,
@@ -246,6 +250,7 @@ fn cmd_video(
     loop_playback: bool,
     speed: Option<f64>,
     no_hw_accel: bool,
+    fps: Option<u32>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let path = path.canonicalize().map_err(|e| format!("Invalid path: {e}"))?;
 
@@ -254,12 +259,14 @@ fn cmd_video(
     }
 
     let output_name = output.unwrap_or_else(|| "all".to_string());
+    let fps = fps.map(|f| f.clamp(1, 240));
 
     let video_config = VideoConfig {
         path: path.clone(),
         loop_playback,
         playback_speed: speed.unwrap_or(1.0),
         hw_accel: !no_hw_accel,
+        fps_limit: fps,
     };
 
     let entry = Entry::new(output_name.clone(), Source::Video(video_config));
@@ -276,6 +283,9 @@ fn cmd_video(
     }
     if no_hw_accel {
         println!("  Hardware acceleration: disabled");
+    }
+    if let Some(f) = fps {
+        println!("  FPS limit: {f}");
     }
     Ok(())
 }
@@ -497,6 +507,7 @@ fn print_entry(entry: &Entry) {
             println!("  Loop: {}", v.loop_playback);
             println!("  Speed: {}x", v.playback_speed);
             println!("  HW Accel: {}", v.hw_accel);
+            println!("  FPS limit: {}", v.target_fps());
         }
         Source::Animated(a) => {
             println!("  Type: Animated image\n  Path: {}", a.path.display());

--- a/src/bin/cosmic-bg-ctl.rs
+++ b/src/bin/cosmic-bg-ctl.rs
@@ -60,6 +60,9 @@ enum Commands {
         /// Target FPS limit (default: 60)
         #[arg(long)]
         fps: Option<u32>,
+        /// Scaling mode: stretch, zoom, fit, fit-blur
+        #[arg(long, default_value = "stretch")]
+        scaling: String,
     },
 
     /// Set an animated image wallpaper (GIF, WebP, APNG)
@@ -166,7 +169,8 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             speed,
             no_hw_accel,
             fps,
-        } => cmd_video(&context, path, output, r#loop, speed, no_hw_accel, fps),
+            scaling,
+        } => cmd_video(&context, path, output, r#loop, speed, no_hw_accel, fps, &scaling),
         Commands::Animated {
             path,
             output,
@@ -197,7 +201,10 @@ fn parse_scaling_mode(scaling: &str) -> Result<ScalingMode, Box<dyn std::error::
         "zoom" => Ok(ScalingMode::Zoom),
         "stretch" => Ok(ScalingMode::Stretch),
         "fit" => Ok(ScalingMode::Fit([0.0, 0.0, 0.0])), // Black background
-        _ => Err(format!("Unknown scaling mode: {scaling}. Use: zoom, fit, stretch").into()),
+        "fit-blur" => Ok(ScalingMode::FitBlur),
+        _ => Err(
+            format!("Unknown scaling mode: {scaling}. Use: zoom, fit, stretch, fit-blur").into(),
+        ),
     }
 }
 
@@ -251,6 +258,7 @@ fn cmd_video(
     speed: Option<f64>,
     no_hw_accel: bool,
     fps: Option<u32>,
+    scaling: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let path = path.canonicalize().map_err(|e| format!("Invalid path: {e}"))?;
 
@@ -260,6 +268,7 @@ fn cmd_video(
 
     let output_name = output.unwrap_or_else(|| "all".to_string());
     let fps = fps.map(|f| f.clamp(1, 240));
+    let scaling_mode = parse_scaling_mode(scaling)?;
 
     let video_config = VideoConfig {
         path: path.clone(),
@@ -269,7 +278,8 @@ fn cmd_video(
         fps_limit: fps,
     };
 
-    let entry = Entry::new(output_name.clone(), Source::Video(video_config));
+    let mut entry = Entry::new(output_name.clone(), Source::Video(video_config));
+    entry.scaling_mode = scaling_mode;
 
     let mut config = cosmic_ext_bg_config::Config::load(context)?;
     config.set_entry(context, entry)?;
@@ -287,6 +297,7 @@ fn cmd_video(
     if let Some(f) = fps {
         println!("  FPS limit: {f}");
     }
+    println!("  Scaling: {scaling}");
     Ok(())
 }
 
@@ -627,4 +638,25 @@ fn cmd_restore(
 
     println!("Configuration restored from: {}", backup_file.display());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_video_scaling_modes() {
+        assert_eq!(parse_scaling_mode("stretch").unwrap(), ScalingMode::Stretch);
+        assert_eq!(parse_scaling_mode("zoom").unwrap(), ScalingMode::Zoom);
+        assert_eq!(
+            parse_scaling_mode("fit").unwrap(),
+            ScalingMode::Fit([0.0, 0.0, 0.0])
+        );
+        assert_eq!(parse_scaling_mode("fit-blur").unwrap(), ScalingMode::FitBlur);
+    }
+
+    #[test]
+    fn rejects_unknown_scaling_mode() {
+        assert!(parse_scaling_mode("contain").is_err());
+    }
 }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -41,6 +41,39 @@ pub fn canvas(
     Ok(buffer)
 }
 
+pub fn canvas_from_bgrx(
+    pool: &mut SlotPool,
+    data: &[u8],
+    width: u32,
+    height: u32,
+    source_stride: usize,
+) -> Result<Buffer, CreateBufferError> {
+    let stride = width as i32 * 4;
+    let (buffer, canvas) = pool.create_buffer(width as i32, height as i32, stride, wl_shm::Format::Xrgb8888)?;
+
+    copy_bgrx_to_xrgb8888(canvas, data, width as usize, height as usize, source_stride, stride as usize);
+
+    Ok(buffer)
+}
+
+pub fn copy_bgrx_to_xrgb8888(
+    canvas: &mut [u8],
+    data: &[u8],
+    width: usize,
+    height: usize,
+    source_stride: usize,
+    dest_stride: usize,
+) {
+    let row_bytes = width * 4;
+    for row in 0..height {
+        let src_start = row * source_stride;
+        let src_end = src_start + row_bytes;
+        let dst_start = row * dest_stride;
+        let dst_end = dst_start + row_bytes;
+        canvas[dst_start..dst_end].copy_from_slice(&data[src_start..src_end]);
+    }
+}
+
 pub fn layer_surface(
     layer: &mut CosmicBgLayer,
     queue_handle: &QueueHandle<CosmicBg>,
@@ -103,6 +136,28 @@ pub fn xrgb888_canvas(canvas: &mut [u8], image: &DynamicImage) {
         "canvas too small: {} bytes for {}x{} image",
         canvas.len(), image.width(), image.height()
     );
+
+    if let Some(image) = image.as_rgba8() {
+        for (source, target) in image.as_raw().chunks_exact(4).zip(canvas.chunks_exact_mut(4)) {
+            let [r, g, b, _] = source else {
+                unreachable!("RGBA chunks are exactly 4 bytes");
+            };
+
+            target.copy_from_slice(&[*b, *g, *r, 0]);
+        }
+        return;
+    }
+
+    if let Some(image) = image.as_rgb8() {
+        for (source, target) in image.as_raw().chunks_exact(3).zip(canvas.chunks_exact_mut(4)) {
+            let [r, g, b] = source else {
+                unreachable!("RGB chunks are exactly 3 bytes");
+            };
+
+            target.copy_from_slice(&[*b, *g, *r, 0]);
+        }
+        return;
+    }
 
     for (pos, (_, _, pixel)) in image.pixels().enumerate() {
         let indice = pos * 4;

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -56,6 +56,77 @@ pub fn canvas_from_bgrx(
     Ok(buffer)
 }
 
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
+pub fn canvas_from_fit_blur_bgrx(
+    pool: &mut SlotPool,
+    background: &[u8],
+    frame: &[u8],
+    frame_width: u32,
+    frame_height: u32,
+    frame_stride: usize,
+    layer_width: u32,
+    layer_height: u32,
+) -> Result<Buffer, CreateBufferError> {
+    let stride = layer_width as i32 * 4;
+    let (buffer, canvas) = pool.create_buffer(
+        layer_width as i32,
+        layer_height as i32,
+        stride,
+        wl_shm::Format::Xrgb8888,
+    )?;
+
+    crate::scaler::compose_fit_blur_bgrx_to_canvas(
+        canvas,
+        stride as usize,
+        background,
+        frame,
+        frame_width,
+        frame_height,
+        frame_stride,
+        layer_width,
+        layer_height,
+    );
+
+    Ok(buffer)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn canvas_from_fit_blur_bgrx_with_workspace(
+    pool: &mut SlotPool,
+    background: &[u8],
+    frame: &[u8],
+    frame_width: u32,
+    frame_height: u32,
+    frame_stride: usize,
+    layer_width: u32,
+    layer_height: u32,
+    workspace: &mut crate::scaler::FitBlurBgrxWorkspace,
+) -> Result<Buffer, CreateBufferError> {
+    let stride = layer_width as i32 * 4;
+    let (buffer, canvas) = pool.create_buffer(
+        layer_width as i32,
+        layer_height as i32,
+        stride,
+        wl_shm::Format::Xrgb8888,
+    )?;
+
+    crate::scaler::compose_fit_blur_bgrx_to_canvas_with_workspace(
+        canvas,
+        stride as usize,
+        background,
+        frame,
+        frame_width,
+        frame_height,
+        frame_stride,
+        layer_width,
+        layer_height,
+        workspace,
+    );
+
+    Ok(buffer)
+}
+
 pub fn copy_bgrx_to_xrgb8888(
     canvas: &mut [u8],
     data: &[u8],

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ mod malloc {
 use cosmic_ext_bg_config::{Config, state::State};
 use cosmic_config::{CosmicConfigEntry, calloop::ConfigWatchSource};
 use eyre::Context;
+use std::time::Instant;
 use sctk::{
     compositor::{CompositorHandler, CompositorState},
     delegate_compositor, delegate_layer, delegate_output, delegate_registry, delegate_shm,
@@ -97,6 +98,7 @@ pub struct CosmicBgLayer {
     output_info: OutputInfo,
     pool: Option<SlotPool>,
     needs_redraw: bool,
+    last_video_frame_draw: Option<Instant>,
     size: Option<(u32, u32)>,
     fractional_scale: Option<u32>,
     transform: wl_output::Transform,
@@ -402,6 +404,7 @@ impl CosmicBg {
             size: None,
             fractional_scale,
             needs_redraw: false,
+            last_video_frame_draw: None,
             pool: None,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -434,9 +434,14 @@ impl CompositorHandler for CosmicBg {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _surface: &wl_surface::WlSurface,
+        surface: &wl_surface::WlSurface,
         _time: u32,
     ) {
+        for wallpaper in &mut self.wallpapers {
+            if wallpaper.draw_video_frame_for_surface(surface) {
+                break;
+            }
+        }
     }
 
     fn transform_changed(

--- a/src/scaler.rs
+++ b/src/scaler.rs
@@ -3,7 +3,31 @@
 //! Background scaling methods such as fit, stretch, and zoom.
 
 use image::imageops::FilterType;
-use image::{DynamicImage, Pixel};
+use image::{DynamicImage, Pixel, RgbaImage};
+use std::borrow::Cow;
+use std::sync::Arc;
+
+const FIT_BLUR_RADIUS: f32 = 24.0;
+const FIT_BLUR_BACKGROUND_MAX_SIZE: u32 = 960;
+const FIT_BLUR_FOREGROUND_FEATHER_PX: u32 = 40;
+const VIDEO_FIT_BLUR_FOREGROUND_FILTER: fast_image_resize::FilterType =
+    fast_image_resize::FilterType::Bilinear;
+
+pub struct FitBlurBgrxWorkspace {
+    resizer: fast_image_resize::Resizer,
+    foreground: Vec<u8>,
+    normalized: Vec<u8>,
+}
+
+impl Default for FitBlurBgrxWorkspace {
+    fn default() -> Self {
+        Self {
+            resizer: fast_image_resize::Resizer::new(),
+            foreground: Vec::new(),
+            normalized: Vec::new(),
+        }
+    }
+}
 
 pub fn fit(
     img: &image::DynamicImage,
@@ -44,6 +68,520 @@ pub fn stretch(
     resize(img, layer_width, layer_height)
 }
 
+pub fn fit_blur(
+    img: &image::DynamicImage,
+    layer_width: u32,
+    layer_height: u32,
+) -> image::DynamicImage {
+    let background = image::imageops::blur(
+        &zoom(img, layer_width, layer_height).to_rgba8(),
+        FIT_BLUR_RADIUS,
+    );
+
+    compose_fit_blur(img, &background, layer_width, layer_height)
+}
+
+pub fn fit_blur_background_fast(
+    img: &image::DynamicImage,
+    layer_width: u32,
+    layer_height: u32,
+) -> RgbaImage {
+    let scale = (FIT_BLUR_BACKGROUND_MAX_SIZE as f64 / layer_width.max(layer_height) as f64)
+        .min(1.0);
+    let background_width = ((layer_width as f64 * scale).round() as u32).max(1);
+    let background_height = ((layer_height as f64 * scale).round() as u32).max(1);
+    let blur_radius = (FIT_BLUR_RADIUS * scale as f32).max(1.0);
+
+    let small_background = image::imageops::blur(
+        &zoom(img, background_width, background_height).to_rgba8(),
+        blur_radius,
+    );
+
+    if background_width == layer_width && background_height == layer_height {
+        small_background
+    } else {
+        image::imageops::resize(
+            &small_background,
+            layer_width,
+            layer_height,
+            FilterType::Triangle,
+        )
+    }
+}
+
+pub fn compose_fit_blur(
+    img: &image::DynamicImage,
+    background: &RgbaImage,
+    layer_width: u32,
+    layer_height: u32,
+) -> image::DynamicImage {
+    let mut background = background.clone();
+    let (w, h) = (img.width(), img.height());
+    let ratio = (layer_width as f64 / w as f64).min(layer_height as f64 / h as f64);
+    let (new_width, new_height) = (
+        (w as f64 * ratio).round() as u32,
+        (h as f64 * ratio).round() as u32,
+    );
+    let foreground = resize(img, new_width, new_height).to_rgba8();
+    let foreground_x = (layer_width - new_width) / 2;
+    let foreground_y = (layer_height - new_height) / 2;
+
+    overlay_fit_blur_foreground(
+        &mut background,
+        &foreground,
+        foreground_x,
+        foreground_y,
+        layer_width,
+        layer_height,
+    );
+
+    DynamicImage::ImageRgba8(background)
+}
+
+pub fn fit_blur_background_to_bgrx(background: &RgbaImage) -> Arc<[u8]> {
+    let mut bgrx = Vec::with_capacity(background.as_raw().len());
+    for pixel in background.as_raw().chunks_exact(4) {
+        let [r, g, b, _a] = pixel else {
+            unreachable!("RGBA chunks are exactly 4 bytes");
+        };
+        bgrx.extend_from_slice(&[*b, *g, *r, 0]);
+    }
+    Arc::from(bgrx)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn compose_fit_blur_bgrx_to_canvas(
+    canvas: &mut [u8],
+    canvas_stride: usize,
+    background: &[u8],
+    frame: &[u8],
+    frame_width: u32,
+    frame_height: u32,
+    frame_stride: usize,
+    layer_width: u32,
+    layer_height: u32,
+) {
+    let mut workspace = FitBlurBgrxWorkspace::default();
+    compose_fit_blur_bgrx_to_canvas_with_workspace(
+        canvas,
+        canvas_stride,
+        background,
+        frame,
+        frame_width,
+        frame_height,
+        frame_stride,
+        layer_width,
+        layer_height,
+        &mut workspace,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn compose_fit_blur_bgrx_to_canvas_with_workspace(
+    canvas: &mut [u8],
+    canvas_stride: usize,
+    background: &[u8],
+    frame: &[u8],
+    frame_width: u32,
+    frame_height: u32,
+    frame_stride: usize,
+    layer_width: u32,
+    layer_height: u32,
+    workspace: &mut FitBlurBgrxWorkspace,
+) {
+    let layer_width_usize = layer_width as usize;
+    let layer_height_usize = layer_height as usize;
+    let Some(layer_row_bytes) = layer_width_usize.checked_mul(4) else {
+        tracing::warn!("Invalid fit-blur BGRx layer dimensions");
+        return;
+    };
+
+    if canvas_stride < layer_row_bytes {
+        tracing::warn!("Invalid fit-blur BGRx canvas stride");
+        return;
+    }
+    let Some(canvas_len) = required_len(canvas_stride, layer_height_usize, layer_row_bytes) else {
+        tracing::warn!("Invalid fit-blur BGRx canvas dimensions");
+        return;
+    };
+    let Some(background_len) = layer_row_bytes.checked_mul(layer_height_usize) else {
+        tracing::warn!("Invalid fit-blur BGRx background dimensions");
+        return;
+    };
+    if canvas.len() < canvas_len || background.len() < background_len {
+        tracing::warn!("Fit-blur BGRx canvas or background buffer is too small");
+        return;
+    }
+
+    for row in 0..layer_height_usize {
+        let dst_start = row * canvas_stride;
+        let src_start = row * layer_row_bytes;
+        canvas[dst_start..dst_start + layer_row_bytes]
+            .copy_from_slice(&background[src_start..src_start + layer_row_bytes]);
+    }
+
+    if frame_width == 0 || frame_height == 0 || layer_width == 0 || layer_height == 0 {
+        tracing::warn!("Invalid fit-blur BGRx foreground dimensions");
+        return;
+    }
+
+    let (foreground_width, foreground_height) = fit_blur_foreground_size(
+        frame_width,
+        frame_height,
+        layer_width,
+        layer_height,
+    );
+    let foreground = resize_bgrx(
+        frame,
+        frame_width,
+        frame_height,
+        frame_stride,
+        foreground_width,
+        foreground_height,
+        workspace,
+    );
+    let foreground_x = (layer_width - foreground_width) / 2;
+    let foreground_y = (layer_height - foreground_height) / 2;
+
+    overlay_fit_blur_bgrx_foreground(
+        canvas,
+        canvas_stride,
+        foreground,
+        foreground_width,
+        foreground_height,
+        foreground_x,
+        foreground_y,
+        layer_width,
+        layer_height,
+    );
+}
+
+fn fit_blur_foreground_size(
+    frame_width: u32,
+    frame_height: u32,
+    layer_width: u32,
+    layer_height: u32,
+) -> (u32, u32) {
+    let ratio =
+        (layer_width as f64 / frame_width as f64).min(layer_height as f64 / frame_height as f64);
+    (
+        (frame_width as f64 * ratio).round() as u32,
+        (frame_height as f64 * ratio).round() as u32,
+    )
+}
+
+fn resize_bgrx<'a>(
+    frame: &[u8],
+    frame_width: u32,
+    frame_height: u32,
+    frame_stride: usize,
+    new_width: u32,
+    new_height: u32,
+    workspace: &'a mut FitBlurBgrxWorkspace,
+) -> &'a [u8] {
+    let FitBlurBgrxWorkspace {
+        resizer,
+        foreground,
+        normalized,
+    } = workspace;
+    let Some(source) =
+        normalized_bgrx_rows_with_scratch(frame, frame_width, frame_height, frame_stride, normalized)
+    else {
+        tracing::warn!("Invalid BGRx frame dimensions. Skipping foreground resize.");
+        foreground.clear();
+        return foreground;
+    };
+
+    let Ok(src_image) = fast_image_resize::images::ImageRef::new(
+        frame_width,
+        frame_height,
+        &source,
+        fast_image_resize::PixelType::U8x4,
+    ) else {
+        *foreground = resize_bgrx_fallback(&source, frame_width, frame_height, new_width, new_height);
+        return foreground;
+    };
+
+    let Some(foreground_len) = (new_width as usize)
+        .checked_mul(new_height as usize)
+        .and_then(|pixels| pixels.checked_mul(4))
+    else {
+        tracing::warn!("Invalid BGRx resize dimensions. Skipping foreground resize.");
+        foreground.clear();
+        return foreground;
+    };
+    foreground.resize(foreground_len, 0);
+
+    let Ok(mut dst_image) = fast_image_resize::images::Image::from_slice_u8(
+        new_width,
+        new_height,
+        foreground.as_mut_slice(),
+        fast_image_resize::PixelType::U8x4,
+    ) else {
+        *foreground = resize_bgrx_fallback(&source, frame_width, frame_height, new_width, new_height);
+        return foreground;
+    };
+    let options = fast_image_resize::ResizeOptions {
+        algorithm: fast_image_resize::ResizeAlg::Convolution(
+            VIDEO_FIT_BLUR_FOREGROUND_FILTER,
+        ),
+        mul_div_alpha: false,
+        ..Default::default()
+    };
+
+    if let Err(err) = resizer.resize(&src_image, &mut dst_image, &options) {
+        tracing::warn!(?err, "Failed to resize BGRx frame. Falling back.");
+        *foreground = resize_bgrx_fallback(&source, frame_width, frame_height, new_width, new_height);
+        return foreground;
+    }
+
+    drop(dst_image);
+    foreground
+}
+
+#[cfg(test)]
+fn normalized_bgrx_rows(
+    frame: &[u8],
+    width: u32,
+    height: u32,
+    stride: usize,
+) -> Option<Cow<'_, [u8]>> {
+    let row_bytes = (width as usize).checked_mul(4)?;
+    let height = height as usize;
+    let required = required_len(stride, height, row_bytes)?;
+    if stride < row_bytes || frame.len() < required {
+        return None;
+    }
+
+    if stride == row_bytes {
+        return Some(Cow::Borrowed(&frame[..row_bytes * height]));
+    }
+
+    let mut compact = Vec::with_capacity(row_bytes * height);
+    for row in 0..height {
+        let start = row * stride;
+        for pixel in frame[start..start + row_bytes].chunks_exact(4) {
+            compact.extend_from_slice(&[pixel[0], pixel[1], pixel[2], 255]);
+        }
+    }
+    Some(Cow::Owned(compact))
+}
+
+fn normalized_bgrx_rows_with_scratch<'a>(
+    frame: &'a [u8],
+    width: u32,
+    height: u32,
+    stride: usize,
+    scratch: &'a mut Vec<u8>,
+) -> Option<Cow<'a, [u8]>> {
+    let row_bytes = (width as usize).checked_mul(4)?;
+    let height = height as usize;
+    let required = required_len(stride, height, row_bytes)?;
+    if stride < row_bytes || frame.len() < required {
+        return None;
+    }
+
+    if stride == row_bytes {
+        return Some(Cow::Borrowed(&frame[..row_bytes * height]));
+    }
+
+    scratch.clear();
+    scratch.reserve(row_bytes * height);
+    for row in 0..height {
+        let start = row * stride;
+        for pixel in frame[start..start + row_bytes].chunks_exact(4) {
+            scratch.extend_from_slice(&[pixel[0], pixel[1], pixel[2], 255]);
+        }
+    }
+    Some(Cow::Borrowed(scratch))
+}
+
+fn required_len(stride: usize, height: usize, row_bytes: usize) -> Option<usize> {
+    match height {
+        0 => Some(0),
+        _ => stride.checked_mul(height - 1)?.checked_add(row_bytes),
+    }
+}
+
+fn resize_bgrx_fallback(
+    source: &[u8],
+    frame_width: u32,
+    frame_height: u32,
+    new_width: u32,
+    new_height: u32,
+) -> Vec<u8> {
+    let mut rgba = Vec::with_capacity(source.len());
+    for pixel in source.chunks_exact(4) {
+        let [b, g, r, _x] = pixel else {
+            unreachable!("BGRx chunks are exactly 4 bytes");
+        };
+        rgba.extend_from_slice(&[*r, *g, *b, 255]);
+    }
+
+    let image = image::ImageBuffer::from_raw(frame_width, frame_height, rgba)
+        .map(DynamicImage::ImageRgba8)
+        .expect("fallback source buffer dimensions are valid");
+    let resized = resize(&image, new_width, new_height).to_rgba8();
+    fit_blur_background_to_bgrx(&resized).to_vec()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn overlay_fit_blur_bgrx_foreground(
+    canvas: &mut [u8],
+    canvas_stride: usize,
+    foreground: &[u8],
+    foreground_width: u32,
+    foreground_height: u32,
+    foreground_x: u32,
+    foreground_y: u32,
+    layer_width: u32,
+    layer_height: u32,
+) {
+    if foreground.is_empty() {
+        return;
+    }
+
+    let feather = FIT_BLUR_FOREGROUND_FEATHER_PX
+        .min(foreground_width / 2)
+        .min(foreground_height / 2);
+
+    for y in 0..foreground_height {
+        let src_row_start = y as usize * foreground_width as usize * 4;
+        let dst_row_start =
+            (foreground_y + y) as usize * canvas_stride + foreground_x as usize * 4;
+
+        for x in 0..foreground_width {
+            let src_start = src_row_start + x as usize * 4;
+            let dst_start = dst_row_start + x as usize * 4;
+
+            let alpha = if feather == 0 {
+                255
+            } else {
+                fit_blur_foreground_alpha(
+                    x,
+                    y,
+                    foreground_width,
+                    foreground_height,
+                    foreground_x,
+                    foreground_y,
+                    layer_width,
+                    layer_height,
+                    feather,
+                )
+            };
+
+            if alpha == 255 {
+                canvas[dst_start..dst_start + 4]
+                    .copy_from_slice(&foreground[src_start..src_start + 4]);
+                canvas[dst_start + 3] = 0;
+                continue;
+            }
+
+            for channel in 0..3 {
+                canvas[dst_start + channel] = blend_channel(
+                    canvas[dst_start + channel],
+                    foreground[src_start + channel],
+                    alpha,
+                );
+            }
+            canvas[dst_start + 3] = 0;
+        }
+    }
+}
+
+fn overlay_fit_blur_foreground(
+    background: &mut RgbaImage,
+    foreground: &RgbaImage,
+    foreground_x: u32,
+    foreground_y: u32,
+    layer_width: u32,
+    layer_height: u32,
+) {
+    let foreground_width = foreground.width();
+    let foreground_height = foreground.height();
+    let feather = FIT_BLUR_FOREGROUND_FEATHER_PX
+        .min(foreground_width / 2)
+        .min(foreground_height / 2);
+
+    if feather == 0 {
+        image::imageops::replace(
+            background,
+            foreground,
+            foreground_x.into(),
+            foreground_y.into(),
+        );
+        return;
+    }
+
+    for y in 0..foreground_height {
+        for x in 0..foreground_width {
+            let alpha = fit_blur_foreground_alpha(
+                x,
+                y,
+                foreground_width,
+                foreground_height,
+                foreground_x,
+                foreground_y,
+                layer_width,
+                layer_height,
+                feather,
+            );
+            let foreground_pixel = foreground.get_pixel(x, y);
+            let background_pixel = background.get_pixel_mut(foreground_x + x, foreground_y + y);
+
+            for channel in 0..3 {
+                background_pixel.0[channel] = blend_channel(
+                    background_pixel.0[channel],
+                    foreground_pixel.0[channel],
+                    alpha,
+                );
+            }
+            background_pixel.0[3] = 255;
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn fit_blur_foreground_alpha(
+    x: u32,
+    y: u32,
+    foreground_width: u32,
+    foreground_height: u32,
+    foreground_x: u32,
+    foreground_y: u32,
+    layer_width: u32,
+    layer_height: u32,
+    feather: u32,
+) -> u8 {
+    let mut edge_distance = feather;
+
+    if foreground_x > 0 {
+        edge_distance = edge_distance.min(x);
+    }
+    if foreground_x + foreground_width < layer_width {
+        edge_distance = edge_distance.min(foreground_width - 1 - x);
+    }
+    if foreground_y > 0 {
+        edge_distance = edge_distance.min(y);
+    }
+    if foreground_y + foreground_height < layer_height {
+        edge_distance = edge_distance.min(foreground_height - 1 - y);
+    }
+
+    if edge_distance >= feather {
+        return 255;
+    }
+
+    let t = edge_distance as f32 / feather as f32;
+    let smooth = t * t * (3.0 - 2.0 * t);
+    (smooth * 255.0).round() as u8
+}
+
+fn blend_channel(background: u8, foreground: u8, alpha: u8) -> u8 {
+    let alpha = alpha as u16;
+    (((foreground as u16 * alpha) + (background as u16 * (255 - alpha)) + 127) / 255) as u8
+}
+
 pub fn zoom(img: &image::DynamicImage, layer_width: u32, layer_height: u32) -> image::DynamicImage {
     let (w, h) = (img.width(), img.height());
 
@@ -82,4 +620,231 @@ fn resize(img: &image::DynamicImage, new_width: u32, new_height: u32) -> image::
             image::imageops::resize(img, new_width, new_height, FilterType::Lanczos3).into();
     }
     new_image
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{ImageBuffer, Rgba};
+
+    #[test]
+    fn fast_fit_blur_background_matches_layer_size() {
+        let image = DynamicImage::ImageRgba8(ImageBuffer::from_pixel(
+            320,
+            180,
+            Rgba([255, 0, 0, 255]),
+        ));
+
+        let background = fit_blur_background_fast(&image, 3440, 1440);
+
+        assert_eq!(background.width(), 3440);
+        assert_eq!(background.height(), 1440);
+    }
+
+    #[test]
+    fn compose_fit_blur_centers_foreground_over_cached_background() {
+        let image = DynamicImage::ImageRgba8(ImageBuffer::from_pixel(
+            100,
+            50,
+            Rgba([255, 0, 0, 255]),
+        ));
+        let background = ImageBuffer::from_pixel(200, 200, Rgba([0, 0, 255, 255]));
+
+        let composed = compose_fit_blur(&image, &background, 200, 200).to_rgba8();
+
+        assert_eq!(composed.get_pixel(100, 100).0, [255, 0, 0, 255]);
+        assert_eq!(composed.get_pixel(100, 10).0, [0, 0, 255, 255]);
+    }
+
+    #[test]
+    fn compose_fit_blur_feathers_only_edges_with_adjacent_background() {
+        let image = DynamicImage::ImageRgba8(ImageBuffer::from_pixel(
+            160,
+            90,
+            Rgba([255, 0, 0, 255]),
+        ));
+        let background = ImageBuffer::from_pixel(344, 144, Rgba([0, 0, 255, 255]));
+
+        let composed = compose_fit_blur(&image, &background, 344, 144).to_rgba8();
+
+        assert_eq!(composed.get_pixel(172, 72).0, [255, 0, 0, 255]);
+        assert_eq!(composed.get_pixel(44, 72).0, [0, 0, 255, 255]);
+        assert_eq!(composed.get_pixel(84, 72).0, [255, 0, 0, 255]);
+        assert_eq!(composed.get_pixel(172, 0).0, [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn compose_fit_blur_blends_foreground_feather_with_background() {
+        let image = DynamicImage::ImageRgba8(ImageBuffer::from_pixel(
+            160,
+            90,
+            Rgba([255, 0, 0, 255]),
+        ));
+        let background = ImageBuffer::from_pixel(344, 144, Rgba([0, 0, 255, 255]));
+
+        let composed = compose_fit_blur(&image, &background, 344, 144).to_rgba8();
+
+        let feather_pixel = composed.get_pixel(64, 72).0;
+        assert!(feather_pixel[0] > 0 && feather_pixel[0] < 255);
+        assert_eq!(feather_pixel[1], 0);
+        assert!(feather_pixel[2] > 0 && feather_pixel[2] < 255);
+        assert_eq!(feather_pixel[3], 255);
+    }
+
+    #[test]
+    fn compose_fit_blur_bgrx_to_canvas_centers_and_feathers() {
+        let background: Vec<u8> = [255, 0, 0, 0].repeat(344 * 144);
+        let foreground: Vec<u8> = [0, 0, 255, 255].repeat(160 * 90);
+        let mut canvas = vec![0; 344 * 144 * 4];
+
+        compose_fit_blur_bgrx_to_canvas(
+            &mut canvas,
+            344 * 4,
+            &background,
+            &foreground,
+            160,
+            90,
+            160 * 4,
+            344,
+            144,
+        );
+
+        let center = (72 * 344 + 172) * 4;
+        let outside = (72 * 344 + 44) * 4;
+        let feather = (72 * 344 + 64) * 4;
+
+        assert_eq!(&canvas[center..center + 4], &[0, 0, 255, 0]);
+        assert_eq!(&canvas[outside..outside + 4], &[255, 0, 0, 0]);
+        assert!(canvas[feather] > 0 && canvas[feather] < 255);
+        assert_eq!(canvas[feather + 1], 0);
+        assert!(canvas[feather + 2] > 0 && canvas[feather + 2] < 255);
+        assert_eq!(canvas[feather + 3], 0);
+    }
+
+    #[test]
+    fn compose_fit_blur_bgrx_tight_zero_x_foreground_keeps_color() {
+        let background: Vec<u8> = [255, 0, 0, 0].repeat(8 * 4);
+        let foreground: Vec<u8> = [0, 0, 255, 0].repeat(2);
+        let mut canvas = vec![0; 8 * 4 * 4];
+
+        compose_fit_blur_bgrx_to_canvas(
+            &mut canvas,
+            8 * 4,
+            &background,
+            &foreground,
+            2,
+            1,
+            2 * 4,
+            8,
+            4,
+        );
+
+        let center = (2 * 8 + 4) * 4;
+        assert_eq!(&canvas[center..center + 4], &[0, 0, 255, 0]);
+    }
+
+    #[test]
+    fn compose_fit_blur_bgrx_workspace_reuses_across_frame_layouts() {
+        let mut workspace = FitBlurBgrxWorkspace::default();
+
+        let background_a: Vec<u8> = [255, 0, 0, 0].repeat(8 * 4);
+        let foreground_a: Vec<u8> = [0, 0, 255, 0].repeat(2);
+        let mut canvas_a = vec![0; 8 * 4 * 4];
+
+        compose_fit_blur_bgrx_to_canvas_with_workspace(
+            &mut canvas_a,
+            8 * 4,
+            &background_a,
+            &foreground_a,
+            2,
+            1,
+            2 * 4,
+            8,
+            4,
+            &mut workspace,
+        );
+
+        let center_a = (2 * 8 + 4) * 4;
+        assert_eq!(&canvas_a[center_a..center_a + 4], &[0, 0, 255, 0]);
+
+        let background_b: Vec<u8> = [0, 255, 0, 0].repeat(6 * 8);
+        let foreground_b = [
+            0, 0, 255, 0, 0, 0, 255, 0, 99, 99, 99, 99, 0, 0, 255, 0, 0, 0, 255, 0, 99,
+            99, 99, 99,
+        ];
+        let mut canvas_b = vec![0; 6 * 8 * 4];
+
+        compose_fit_blur_bgrx_to_canvas_with_workspace(
+            &mut canvas_b,
+            6 * 4,
+            &background_b,
+            &foreground_b,
+            2,
+            2,
+            12,
+            6,
+            8,
+            &mut workspace,
+        );
+
+        let center_b = (4 * 6 + 3) * 4;
+        assert_eq!(canvas_b[center_b], 0);
+        assert!(canvas_b[center_b + 1] < 255);
+        assert!(canvas_b[center_b + 2] > 0);
+        assert_eq!(canvas_b[center_b + 3], 0);
+        assert_eq!(&canvas_b[..4], &[0, 255, 0, 0]);
+    }
+
+    #[test]
+    fn compose_fit_blur_bgrx_to_canvas_rejects_short_buffers() {
+        let background = vec![0; 4];
+        let foreground = vec![0; 4];
+        let mut canvas = vec![0; 4];
+
+        compose_fit_blur_bgrx_to_canvas(
+            &mut canvas,
+            4,
+            &background,
+            &foreground,
+            2,
+            1,
+            8,
+            8,
+            4,
+        );
+
+        assert_eq!(canvas, vec![0; 4]);
+    }
+
+    #[test]
+    fn normalized_bgrx_rows_borrows_tightly_packed_frame() {
+        let frame: Vec<u8> = [1, 2, 3, 4].repeat(4);
+
+        let normalized = normalized_bgrx_rows(&frame, 2, 2, 2 * 4).unwrap();
+
+        assert!(matches!(normalized, Cow::Borrowed(_)));
+        assert_eq!(&*normalized, &frame);
+    }
+
+    #[test]
+    fn normalized_bgrx_rows_compacts_strided_frame() {
+        let frame = [
+            1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 9, 10, 11, 12, 13, 14, 15, 16, 0, 0,
+        ];
+
+        let normalized = normalized_bgrx_rows(&frame, 2, 2, 10).unwrap();
+
+        assert!(matches!(normalized, Cow::Owned(_)));
+        assert_eq!(
+            &*normalized,
+            &[1, 2, 3, 255, 5, 6, 7, 255, 9, 10, 11, 255, 13, 14, 15, 255]
+        );
+    }
+
+    #[test]
+    fn normalized_bgrx_rows_rejects_short_frame() {
+        let frame = [1, 2, 3, 4];
+
+        assert!(normalized_bgrx_rows(&frame, 2, 1, 8).is_none());
+    }
 }

--- a/src/scaler.rs
+++ b/src/scaler.rs
@@ -213,15 +213,11 @@ pub fn compose_fit_blur_bgrx_to_canvas_with_workspace(
         return;
     }
 
-    for row in 0..layer_height_usize {
-        let dst_start = row * canvas_stride;
-        let src_start = row * layer_row_bytes;
-        canvas[dst_start..dst_start + layer_row_bytes]
-            .copy_from_slice(&background[src_start..src_start + layer_row_bytes]);
-    }
-
     if frame_width == 0 || frame_height == 0 || layer_width == 0 || layer_height == 0 {
         tracing::warn!("Invalid fit-blur BGRx foreground dimensions");
+        // Fill with the blurred background so the surface is never left with
+        // uninitialized (recycled) buffer contents.
+        copy_background_to_canvas(canvas, canvas_stride, background, layer_row_bytes, layer_height_usize);
         return;
     }
 
@@ -231,15 +227,55 @@ pub fn compose_fit_blur_bgrx_to_canvas_with_workspace(
         layer_width,
         layer_height,
     );
-    let foreground = resize_bgrx(
-        frame,
-        frame_width,
-        frame_height,
-        frame_stride,
-        foreground_width,
-        foreground_height,
-        workspace,
-    );
+
+    let foreground_row_bytes = foreground_width as usize * 4;
+    let covers_layer = foreground_width == layer_width && foreground_height == layer_height;
+    let identity_scale = foreground_width == frame_width && foreground_height == frame_height;
+
+    // Fast path: the fitted video fills the whole layer at native resolution.
+    // The blurred background is then fully hidden and the foreground needs no
+    // rescale, so a single per-row copy replaces the full-screen background
+    // fill, the identity resize, and the per-pixel feathered overlay. This is
+    // the common case for full-screen-aspect video (e.g. a 16:9 clip on a 16:9
+    // output) and removes ~3 full-frame passes plus the resampler per frame.
+    if covers_layer
+        && identity_scale
+        && copy_bgrx_frame_to_canvas(
+            canvas,
+            canvas_stride,
+            frame,
+            frame_width,
+            frame_height,
+            frame_stride,
+        )
+    {
+        return;
+    }
+
+    // The blurred background is only visible where the foreground does not cover
+    // the layer, so skip the full-screen copy when the foreground fills it.
+    if !covers_layer {
+        copy_background_to_canvas(canvas, canvas_stride, background, layer_row_bytes, layer_height_usize);
+    }
+
+    // Skip the resampler when the foreground is already at native size; the raw
+    // BGRx frame can be overlaid directly.
+    let foreground: &[u8] = if identity_scale
+        && frame_stride == foreground_row_bytes
+        && frame.len() >= foreground_row_bytes * foreground_height as usize
+    {
+        &frame[..foreground_row_bytes * foreground_height as usize]
+    } else {
+        resize_bgrx(
+            frame,
+            frame_width,
+            frame_height,
+            frame_stride,
+            foreground_width,
+            foreground_height,
+            workspace,
+        )
+    };
     let foreground_x = (layer_width - foreground_width) / 2;
     let foreground_y = (layer_height - foreground_height) / 2;
 
@@ -268,6 +304,60 @@ fn fit_blur_foreground_size(
         (frame_width as f64 * ratio).round() as u32,
         (frame_height as f64 * ratio).round() as u32,
     )
+}
+
+/// Copies the full-screen blurred background into the canvas, honouring the
+/// canvas stride. The background is stored tightly packed at `layer_row_bytes`.
+fn copy_background_to_canvas(
+    canvas: &mut [u8],
+    canvas_stride: usize,
+    background: &[u8],
+    layer_row_bytes: usize,
+    layer_height: usize,
+) {
+    for row in 0..layer_height {
+        let dst_start = row * canvas_stride;
+        let src_start = row * layer_row_bytes;
+        canvas[dst_start..dst_start + layer_row_bytes]
+            .copy_from_slice(&background[src_start..src_start + layer_row_bytes]);
+    }
+}
+
+/// Copies a native-resolution BGRx frame straight into the XRGB8888 canvas, one
+/// row at a time to honour differing source/destination strides. BGRx and
+/// XRGB8888 share byte layout, so no per-pixel conversion is needed. Returns
+/// `false` without touching the canvas when the frame buffer is too small, so
+/// the caller can fall back to the full compositing path.
+fn copy_bgrx_frame_to_canvas(
+    canvas: &mut [u8],
+    canvas_stride: usize,
+    frame: &[u8],
+    frame_width: u32,
+    frame_height: u32,
+    frame_stride: usize,
+) -> bool {
+    let row_bytes = frame_width as usize * 4;
+    let height = frame_height as usize;
+    if frame_stride < row_bytes {
+        return false;
+    }
+    let (Some(required_src), Some(required_dst)) = (
+        required_len(frame_stride, height, row_bytes),
+        required_len(canvas_stride, height, row_bytes),
+    ) else {
+        return false;
+    };
+    if frame.len() < required_src || canvas.len() < required_dst {
+        return false;
+    }
+
+    for row in 0..height {
+        let src_start = row * frame_stride;
+        let dst_start = row * canvas_stride;
+        canvas[dst_start..dst_start + row_bytes]
+            .copy_from_slice(&frame[src_start..src_start + row_bytes]);
+    }
+    true
 }
 
 fn resize_bgrx<'a>(
@@ -793,6 +883,77 @@ mod tests {
         assert!(canvas_b[center_b + 2] > 0);
         assert_eq!(canvas_b[center_b + 3], 0);
         assert_eq!(&canvas_b[..4], &[0, 255, 0, 0]);
+    }
+
+    #[test]
+    fn compose_fit_blur_bgrx_full_cover_copies_frame_without_background_or_feather() {
+        let mut workspace = FitBlurBgrxWorkspace::default();
+
+        // Layer and frame are identical 4x2 BGRx buffers, so the fitted video
+        // fills the whole layer at native resolution (the fast path).
+        let layer_width = 4u32;
+        let layer_height = 2u32;
+        let row_bytes = layer_width as usize * 4;
+        let pixels = layer_width as usize * layer_height as usize;
+
+        // A distinctive background that must NOT appear anywhere if the fast
+        // path skips both the background fill and the feathered overlay.
+        let background: Vec<u8> = [255, 0, 0, 0].repeat(pixels);
+        let frame: Vec<u8> = [7, 8, 9, 0].repeat(pixels);
+        let mut canvas = vec![0u8; row_bytes * layer_height as usize];
+
+        compose_fit_blur_bgrx_to_canvas_with_workspace(
+            &mut canvas,
+            row_bytes,
+            &background,
+            &frame,
+            layer_width,
+            layer_height,
+            row_bytes,
+            layer_width,
+            layer_height,
+            &mut workspace,
+        );
+
+        // Every pixel — including the corners the feather would otherwise blend
+        // with the red background — equals the source frame untouched.
+        assert_eq!(canvas, frame);
+    }
+
+    #[test]
+    fn compose_fit_blur_bgrx_full_cover_honours_canvas_stride() {
+        let mut workspace = FitBlurBgrxWorkspace::default();
+
+        // Same full-cover fast path, but with canvas padding (stride larger than
+        // the visible row) to ensure the per-row copy respects the stride.
+        let layer_width = 4u32;
+        let layer_height = 2u32;
+        let row_bytes = layer_width as usize * 4;
+        let canvas_stride = row_bytes + 8;
+        let pixels = layer_width as usize * layer_height as usize;
+
+        let background: Vec<u8> = [255, 0, 0, 0].repeat(pixels);
+        let frame: Vec<u8> = [7, 8, 9, 0].repeat(pixels);
+        let mut canvas = vec![0u8; canvas_stride * layer_height as usize];
+
+        compose_fit_blur_bgrx_to_canvas_with_workspace(
+            &mut canvas,
+            canvas_stride,
+            &background,
+            &frame,
+            layer_width,
+            layer_height,
+            row_bytes,
+            layer_width,
+            layer_height,
+            &mut workspace,
+        );
+
+        for row in 0..layer_height as usize {
+            let dst = row * canvas_stride;
+            let src = row * row_bytes;
+            assert_eq!(&canvas[dst..dst + row_bytes], &frame[src..src + row_bytes]);
+        }
     }
 
     #[test]

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -426,6 +426,7 @@ impl WallpaperSource for ShaderSource {
         Ok(Frame {
             payload: FramePayload::Image(Arc::new(image)),
             timestamp: Instant::now(),
+            is_placeholder: false,
         })
     }
 

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -5,11 +5,12 @@
 //! This module provides real-time GPU-rendered animated backgrounds
 //! using WGSL shaders. Includes built-in presets and custom shader support.
 
-use crate::source::{Frame, SourceError, WallpaperSource};
+use crate::source::{Frame, FramePayload, SourceError, WallpaperSource};
 use cosmic_ext_bg_config::{ShaderConfig, ShaderPreset};
 use image::{DynamicImage, ImageBuffer, Rgba};
 use std::{
     path::Path,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -423,7 +424,7 @@ impl WallpaperSource for ShaderSource {
         let image = self.render_frame()?;
 
         Ok(Frame {
-            image,
+            payload: FramePayload::Image(Arc::new(image)),
             timestamp: Instant::now(),
         })
     }

--- a/src/source.rs
+++ b/src/source.rs
@@ -13,6 +13,7 @@ use image::DynamicImage;
 use std::{
     fs::File,
     path::PathBuf,
+    sync::Arc,
     time::{Duration, Instant},
 };
 use thiserror::Error;
@@ -26,8 +27,28 @@ pub const FALLBACK_RESOLUTION: (u32, u32) = (1920, 1080);
 /// A single frame to be rendered
 #[derive(Debug)]
 pub struct Frame {
-    pub image: DynamicImage,
+    pub payload: FramePayload,
     pub timestamp: Instant,
+}
+
+#[derive(Debug, Clone)]
+pub enum FramePayload {
+    Image(Arc<DynamicImage>),
+    Bgrx {
+        data: Arc<[u8]>,
+        width: u32,
+        height: u32,
+        stride: usize,
+    },
+}
+
+impl Frame {
+    pub fn from_image(image: Arc<DynamicImage>) -> Self {
+        Self {
+            payload: FramePayload::Image(image),
+            timestamp: Instant::now(),
+        }
+    }
 }
 
 /// Errors that can occur when working with wallpaper sources
@@ -114,7 +135,7 @@ impl WallpaperSource for StaticSource {
         }
 
         Ok(Frame {
-            image: self.cached_image.as_ref().unwrap().clone(),
+            payload: FramePayload::Image(Arc::new(self.cached_image.as_ref().unwrap().clone())),
             timestamp: Instant::now(),
         })
     }
@@ -189,7 +210,7 @@ impl WallpaperSource for ColorSource {
         }
 
         Ok(Frame {
-            image: self.generated.as_ref().unwrap().clone(),
+            payload: FramePayload::Image(Arc::new(self.generated.as_ref().unwrap().clone())),
             timestamp: Instant::now(),
         })
     }
@@ -249,8 +270,11 @@ mod tests {
         let mut source = ColorSource::new(Color::Single([1.0, 0.0, 0.0]));
         source.prepare(100, 100).unwrap();
         let frame = source.next_frame().unwrap();
-        assert_eq!(frame.image.width(), 100);
-        assert_eq!(frame.image.height(), 100);
+        let FramePayload::Image(image) = frame.payload else {
+            panic!("expected image payload");
+        };
+        assert_eq!(image.width(), 100);
+        assert_eq!(image.height(), 100);
         assert!(!source.is_animated());
     }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -29,6 +29,7 @@ pub const FALLBACK_RESOLUTION: (u32, u32) = (1920, 1080);
 pub struct Frame {
     pub payload: FramePayload,
     pub timestamp: Instant,
+    pub is_placeholder: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -47,6 +48,15 @@ impl Frame {
         Self {
             payload: FramePayload::Image(image),
             timestamp: Instant::now(),
+            is_placeholder: false,
+        }
+    }
+
+    pub fn placeholder(payload: FramePayload) -> Self {
+        Self {
+            payload,
+            timestamp: Instant::now(),
+            is_placeholder: true,
         }
     }
 }
@@ -86,6 +96,11 @@ pub trait WallpaperSource: Send + Sync {
     /// Prepare source for rendering at given dimensions
     /// This is called when the output size changes
     fn prepare(&mut self, width: u32, height: u32) -> Result<(), SourceError>;
+
+    /// Prepare source without forcing decoded frames to the output dimensions.
+    fn prepare_unscaled(&mut self) -> Result<(), SourceError> {
+        self.prepare(FALLBACK_RESOLUTION.0, FALLBACK_RESOLUTION.1)
+    }
 
     /// Release resources when no longer needed
     fn release(&mut self);
@@ -137,6 +152,7 @@ impl WallpaperSource for StaticSource {
         Ok(Frame {
             payload: FramePayload::Image(Arc::new(self.cached_image.as_ref().unwrap().clone())),
             timestamp: Instant::now(),
+            is_placeholder: false,
         })
     }
 
@@ -212,6 +228,7 @@ impl WallpaperSource for ColorSource {
         Ok(Frame {
             payload: FramePayload::Image(Arc::new(self.generated.as_ref().unwrap().clone())),
             timestamp: Instant::now(),
+            is_placeholder: false,
         })
     }
 

--- a/src/video.rs
+++ b/src/video.rs
@@ -823,10 +823,26 @@ fn read_ffmpeg_frames(
     latest_frame: Arc<Mutex<Option<Arc<[u8]>>>>,
     ended: Arc<AtomicBool>,
 ) {
+    let mut produced: u64 = 0;
+    let mut window_start = Instant::now();
     loop {
         let mut frame = vec![0; frame_size];
         if stdout.read_exact(&mut frame).is_err() {
             break;
+        }
+        produced += 1;
+        // Report the real decode + pipe throughput periodically so we can tell a
+        // decode/pipe bottleneck (low produced fps) from a render bottleneck.
+        if produced % 48 == 0 {
+            let elapsed = window_start.elapsed().as_secs_f64();
+            if elapsed > 0.0 {
+                tracing::debug!(
+                    produced_fps = 48.0 / elapsed,
+                    frame_bytes = frame_size,
+                    "ffmpeg decode throughput"
+                );
+            }
+            window_start = Instant::now();
         }
         let Ok(mut latest) = latest_frame.lock() else {
             break;

--- a/src/video.rs
+++ b/src/video.rs
@@ -689,14 +689,11 @@ fn ffmpeg_args(config: &VideoConfig, target_size: Option<(u32, u32)>) -> Vec<OsS
         OsString::from("error"),
     ];
 
-    // Enable hardware-accelerated decode when requested. `auto` lets ffmpeg pick
-    // an available method (VA-API, NVDEC, etc.) and transparently falls back to
-    // software decode when none is usable, so it is safe to pass unconditionally
-    // when hw_accel is on. Decoded frames stay in system memory (no
-    // hwaccel_output_format), keeping the downstream rawvideo pipe unchanged.
-    if config.hw_accel {
-        args.extend([OsString::from("-hwaccel"), OsString::from("auto")]);
-    }
+    // Note: ffmpeg's native software H.264/AV1 decoders are used deliberately.
+    // Benchmarking 4K H.264 showed `-hwaccel auto` was slower end-to-end than
+    // software decode here because the GPU->system-memory frame download costs
+    // more than it saves for the rawvideo pipe. Software decode already sustains
+    // well above real-time, so the bottleneck is not decode.
 
     if config.loop_playback {
         args.extend([OsString::from("-stream_loop"), OsString::from("-1")]);
@@ -1172,35 +1169,6 @@ mod tests {
 
         assert!(re_index < input_index);
         assert_eq!(args.get(input_index + 1).map(OsString::as_os_str), Some(path.as_os_str()));
-    }
-
-    #[test]
-    fn test_ffmpeg_args_enable_hwaccel_when_requested_before_input() {
-        let config = VideoConfig {
-            path: PathBuf::from("/tmp/video.mp4"),
-            hw_accel: true,
-            ..Default::default()
-        };
-
-        let args = ffmpeg_args(&config, None);
-
-        assert!(os_args_contain_pair(&args, "-hwaccel", "auto"));
-        let hwaccel_index = os_args_position(&args, "-hwaccel").unwrap();
-        let input_index = os_args_position(&args, "-i").unwrap();
-        assert!(hwaccel_index < input_index);
-    }
-
-    #[test]
-    fn test_ffmpeg_args_omit_hwaccel_when_disabled() {
-        let config = VideoConfig {
-            path: PathBuf::from("/tmp/video.mp4"),
-            hw_accel: false,
-            ..Default::default()
-        };
-
-        let args = ffmpeg_args(&config, None);
-
-        assert!(!os_args_contain(&args, "-hwaccel"));
     }
 
     #[test]

--- a/src/video.rs
+++ b/src/video.rs
@@ -1,15 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::source::{Frame, SourceError, WallpaperSource};
+use crate::source::{Frame, FramePayload, SourceError, WallpaperSource};
 use cosmic_ext_bg_config::VideoConfig;
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use image::{DynamicImage, ImageBuffer, Rgba};
 use std::{
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, Instant},
 };
+
+const VIDEO_TARGET_FPS: u32 = 60;
+const VIDEO_FRAME_DURATION: Duration = Duration::from_micros(1_000_000 / VIDEO_TARGET_FPS as u64);
 
 /// Helper to convert GStreamer errors to SourceError
 fn gst_error(message: impl Into<String>) -> SourceError {
@@ -35,7 +38,7 @@ pub struct VideoSource {
     config: VideoConfig,
     pipeline: Option<gst::Pipeline>,
     appsink: Option<gst_app::AppSink>,
-    current_frame: Arc<Mutex<Option<DynamicImage>>>,
+    last_frame: Option<FramePayload>,
     target_size: Option<(u32, u32)>,
     frame_duration: Duration,
     is_playing: bool,
@@ -52,9 +55,9 @@ impl VideoSource {
             config,
             pipeline: None,
             appsink: None,
-            current_frame: Arc::new(Mutex::new(None)),
+            last_frame: None,
             target_size: None,
-            frame_duration: crate::source::DEFAULT_FRAME_DURATION,
+            frame_duration: VIDEO_FRAME_DURATION,
             is_playing: false,
             is_prepared: false,
         })
@@ -64,19 +67,15 @@ impl VideoSource {
     fn build_pipeline(&mut self, width: u32, height: u32) -> Result<(), SourceError> {
         let path = self.config.path.to_str().ok_or_else(|| gst_error("Invalid video path"))?;
 
-        // Detect hardware acceleration capabilities
-        let hw_decode = if self.config.hw_accel {
-            Self::detect_hw_decoder()
-        } else {
-            None
-        };
-
-        // Build pipeline string with hardware acceleration if available
-        let decode_element = match hw_decode {
-            Some(HwDecoder::VaApi) => "vaapidecodebin",
-            Some(HwDecoder::Nvdec) => "nvdec",
-            None => "decodebin",
-        };
+        // Detect hardware acceleration capabilities for diagnostics only.
+        //
+        // Modern GStreamer exposes VA-API decoders as codec-specific elements
+        // such as `vah264dec`/`vah265dec` instead of the older
+        // `vaapidecodebin`. Plain `decodebin` can autoplug those hardware
+        // decoders based on rank, so forcing a specific decoder bin here is
+        // less portable across distributions.
+        let hw_decode = self.config.hw_accel.then(Self::detect_hw_decoder).flatten();
+        let decode_element = "decodebin";
 
         tracing::info!(
             hw_accel = ?hw_decode,
@@ -93,6 +92,7 @@ impl VideoSource {
             .map_err(|e| gst_error(format!("Failed to create filesrc: {}", e)))?;
 
         let decodebin = create_element(decode_element)?;
+        let videorate = create_element("videorate")?;
         let videoconvert = create_element("videoconvert")?;
         let videoscale = create_element("videoscale")?;
 
@@ -100,36 +100,50 @@ impl VideoSource {
             .name("sink")
             .build();
 
-        // Configure appsink caps for RGBA format
+        // Configure appsink caps for BGRx format.
         let caps = gst::Caps::builder("video/x-raw")
-            .field("format", "RGBA")
+            .field("format", "BGRx")
             .field("width", width as i32)
             .field("height", height as i32)
+            .field("framerate", gst::Fraction::new(VIDEO_TARGET_FPS as i32, 1))
             .build();
 
         appsink.set_caps(Some(&caps));
-        appsink.set_property("emit-signals", true);
-        appsink.set_property("sync", false); // Don't sync to clock for wallpapers
+        // Keep only the latest frame. Video wallpapers redraw from the most
+        // recent frame, so queueing old frames just adds latency and memory
+        // pressure when the compositor cannot consume at the source framerate.
+        appsink.set_property("max-buffers", 1u32);
+        appsink.set_property("drop", true);
+        // We pull frames on demand from next_frame(), so keep appsink unsynced
+        // to avoid introducing a second pacing clock besides compositor frames.
+        appsink.set_property("sync", false);
 
         // Add elements to pipeline
         pipeline
-            .add_many([&filesrc, &decodebin, &videoconvert, &videoscale, appsink.upcast_ref()])
+            .add_many([
+                &filesrc,
+                &decodebin,
+                &videorate,
+                &videoconvert,
+                &videoscale,
+                appsink.upcast_ref(),
+            ])
             .map_err(|e| gst_error(format!("Failed to add elements to pipeline: {}", e)))?;
 
         // Link static elements
         link_elements(&[&filesrc, &decodebin])?;
-        link_elements(&[&videoconvert, &videoscale, appsink.upcast_ref()])?;
+        link_elements(&[&videorate, &videoconvert, &videoscale, appsink.upcast_ref()])?;
 
         // Handle dynamic pad linking from decodebin
-        let videoconvert_weak = videoconvert.downgrade();
+        let videorate_weak = videorate.downgrade();
         decodebin.connect_pad_added(move |_src, src_pad| {
-            let Some(videoconvert) = videoconvert_weak.upgrade() else {
+            let Some(videorate) = videorate_weak.upgrade() else {
                 return;
             };
 
-            let sink_pad = videoconvert
+            let sink_pad = videorate
                 .static_pad("sink")
-                .expect("videoconvert has no sink pad");
+                .expect("videorate has no sink pad");
 
             if sink_pad.is_linked() {
                 return;
@@ -149,42 +163,6 @@ impl VideoSource {
                 }
             }
         });
-
-        // Setup appsink callbacks
-        let current_frame = Arc::clone(&self.current_frame);
-        appsink.set_callbacks(
-            gst_app::AppSinkCallbacks::builder()
-                .new_sample(move |appsink| {
-                    let sample = appsink.pull_sample().map_err(|_| gst::FlowError::Error)?;
-
-                    if let Some(buffer) = sample.buffer() {
-                        let map = buffer.map_readable().map_err(|_| gst::FlowError::Error)?;
-                        let caps = sample.caps().ok_or(gst::FlowError::Error)?;
-                        let structure = caps.structure(0).ok_or(gst::FlowError::Error)?;
-
-                        let width = structure
-                            .get::<i32>("width")
-                            .map_err(|_| gst::FlowError::Error)? as u32;
-                        let height = structure
-                            .get::<i32>("height")
-                            .map_err(|_| gst::FlowError::Error)? as u32;
-
-                        if let Some(img_buffer) = ImageBuffer::<Rgba<u8>, _>::from_raw(
-                            width,
-                            height,
-                            map.as_slice().to_vec(),
-                        ) {
-                            let image = DynamicImage::ImageRgba8(img_buffer);
-                            if let Ok(mut frame) = current_frame.lock() {
-                                *frame = Some(image);
-                            }
-                        }
-                    }
-
-                    Ok(gst::FlowSuccess::Ok)
-                })
-                .build(),
-        );
 
         // Store pipeline and appsink
         self.pipeline = Some(pipeline.clone());
@@ -208,21 +186,31 @@ impl VideoSource {
         Ok(())
     }
 
-    /// Detect available hardware decoder
+    /// Detect available hardware decoder families.
     fn detect_hw_decoder() -> Option<HwDecoder> {
-        // Check for VA-API support (Intel, AMD)
-        if gst::ElementFactory::find("vaapidecodebin").is_some() {
-            tracing::info!("VA-API hardware acceleration available");
+        // Check modern VA-API support (Intel, AMD). Fedora and other current
+        // distributions expose hardware decoders through the `va` plugin as
+        // codec-specific elements instead of the legacy `vaapi` plugin.
+        if ["vah264dec", "vah265dec", "vaav1dec", "vavp8dec", "vavp9dec"]
+            .into_iter()
+            .any(|element| gst::ElementFactory::find(element).is_some())
+            || gst::ElementFactory::find("vaapidecodebin").is_some()
+        {
+            tracing::info!("VA-API hardware decoders available through GStreamer");
             return Some(HwDecoder::VaApi);
         }
 
         // Check for NVDEC support (NVIDIA)
-        if gst::ElementFactory::find("nvdec").is_some() {
-            tracing::info!("NVDEC hardware acceleration available");
+        if ["nvh264dec", "nvh265dec", "nvav1dec", "nvvp8dec", "nvvp9dec"]
+            .into_iter()
+            .any(|element| gst::ElementFactory::find(element).is_some())
+            || gst::ElementFactory::find("nvdec").is_some()
+        {
+            tracing::info!("NVDEC hardware decoders available through GStreamer");
             return Some(HwDecoder::Nvdec);
         }
 
-        tracing::info!("No hardware acceleration available, using software decode");
+        tracing::info!("No known hardware decoder factories found; decodebin may use software decode");
         None
     }
 
@@ -301,16 +289,20 @@ impl WallpaperSource for VideoSource {
         // Check for end-of-stream and loop if needed
         self.check_eos()?;
 
-        // Get current frame from buffer
-        let frame_opt = self
-            .current_frame
-            .lock()
-            .ok()
-            .and_then(|guard| guard.clone());
+        if let Some(appsink) = self.appsink.as_ref() {
+            if let Some(sample) = appsink.try_pull_sample(gst::ClockTime::ZERO) {
+                if let Some(frame) = sample_to_frame(&sample) {
+                    self.last_frame = Some(frame);
+                }
+            }
+        }
 
-        if let Some(image) = frame_opt {
+        // Clone only the Arc, not the full image. At ultrawide resolutions a
+        // single full-frame clone costs tens of megabytes, so shared ownership
+        // matters for 60 FPS video.
+        if let Some(payload) = self.last_frame.as_ref() {
             Ok(Frame {
-                image,
+                payload: payload.clone(),
                 timestamp: Instant::now(),
             })
         } else {
@@ -318,7 +310,7 @@ impl WallpaperSource for VideoSource {
             let (width, height) = self.target_size.unwrap_or(crate::source::FALLBACK_RESOLUTION);
             let black = ImageBuffer::from_pixel(width, height, Rgba([0, 0, 0, 255]));
             Ok(Frame {
-                image: DynamicImage::ImageRgba8(black),
+                payload: FramePayload::Image(Arc::new(DynamicImage::ImageRgba8(black))),
                 timestamp: Instant::now(),
             })
         }
@@ -352,7 +344,7 @@ impl WallpaperSource for VideoSource {
 
         self.pipeline = None;
         self.appsink = None;
-        self.current_frame = Arc::new(Mutex::new(None));
+        self.last_frame = None;
         self.is_playing = false;
         self.is_prepared = false;
 
@@ -367,6 +359,62 @@ impl WallpaperSource for VideoSource {
             self.config.hw_accel
         )
     }
+}
+
+fn sample_to_frame(sample: &gst::Sample) -> Option<FramePayload> {
+    let buffer = sample.buffer()?;
+    let map = buffer.map_readable().ok()?;
+    let caps = sample.caps()?;
+    let structure = caps.structure(0)?;
+
+    let width = structure.get::<i32>("width").ok()? as u32;
+    let height = structure.get::<i32>("height").ok()? as u32;
+    let stride = structure.get::<i32>("stride").ok().map(|s| s as usize).unwrap_or(width as usize * 4);
+    let frame_size = stride.checked_mul(height as usize)?;
+
+    if map.as_slice().len() < frame_size {
+        return None;
+    }
+
+    let raw = Arc::<[u8]>::from(map.as_slice()[..frame_size].to_vec());
+
+    Some(FramePayload::Bgrx {
+        data: raw,
+        width,
+        height,
+        stride,
+    })
+}
+
+#[allow(dead_code)]
+fn sample_to_image(sample: &gst::Sample) -> Option<Arc<DynamicImage>> {
+    let payload = sample_to_frame(sample)?;
+    let FramePayload::Bgrx {
+        data,
+        width,
+        height,
+        stride,
+    } = payload
+    else {
+        return None;
+    };
+
+    let mut rgba = vec![0u8; width as usize * height as usize * 4];
+    for row in 0..height as usize {
+        let src_start = row * stride;
+        let src_end = src_start + width as usize * 4;
+        let dst_start = row * width as usize * 4;
+        let src_row = &data[src_start..src_end];
+        let dst_row = &mut rgba[dst_start..dst_start + width as usize * 4];
+
+        for (src, dst) in src_row.chunks_exact(4).zip(dst_row.chunks_exact_mut(4)) {
+            let [b, g, r, _x] = src else { unreachable!() };
+            dst.copy_from_slice(&[*r, *g, *b, 255]);
+        }
+    }
+
+    let img_buffer = ImageBuffer::<Rgba<u8>, _>::from_raw(width, height, rgba)?;
+    Some(Arc::new(DynamicImage::ImageRgba8(img_buffer)))
 }
 
 /// Hardware decoder types

--- a/src/video.rs
+++ b/src/video.rs
@@ -689,6 +689,15 @@ fn ffmpeg_args(config: &VideoConfig, target_size: Option<(u32, u32)>) -> Vec<OsS
         OsString::from("error"),
     ];
 
+    // Enable hardware-accelerated decode when requested. `auto` lets ffmpeg pick
+    // an available method (VA-API, NVDEC, etc.) and transparently falls back to
+    // software decode when none is usable, so it is safe to pass unconditionally
+    // when hw_accel is on. Decoded frames stay in system memory (no
+    // hwaccel_output_format), keeping the downstream rawvideo pipe unchanged.
+    if config.hw_accel {
+        args.extend([OsString::from("-hwaccel"), OsString::from("auto")]);
+    }
+
     if config.loop_playback {
         args.extend([OsString::from("-stream_loop"), OsString::from("-1")]);
     }
@@ -1147,6 +1156,35 @@ mod tests {
 
         assert!(re_index < input_index);
         assert_eq!(args.get(input_index + 1).map(OsString::as_os_str), Some(path.as_os_str()));
+    }
+
+    #[test]
+    fn test_ffmpeg_args_enable_hwaccel_when_requested_before_input() {
+        let config = VideoConfig {
+            path: PathBuf::from("/tmp/video.mp4"),
+            hw_accel: true,
+            ..Default::default()
+        };
+
+        let args = ffmpeg_args(&config, None);
+
+        assert!(os_args_contain_pair(&args, "-hwaccel", "auto"));
+        let hwaccel_index = os_args_position(&args, "-hwaccel").unwrap();
+        let input_index = os_args_position(&args, "-i").unwrap();
+        assert!(hwaccel_index < input_index);
+    }
+
+    #[test]
+    fn test_ffmpeg_args_omit_hwaccel_when_disabled() {
+        let config = VideoConfig {
+            path: PathBuf::from("/tmp/video.mp4"),
+            hw_accel: false,
+            ..Default::default()
+        };
+
+        let args = ffmpeg_args(&config, None);
+
+        assert!(!os_args_contain(&args, "-hwaccel"));
     }
 
     #[test]

--- a/src/video.rs
+++ b/src/video.rs
@@ -11,8 +11,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-const VIDEO_TARGET_FPS: u32 = 60;
-const VIDEO_FRAME_DURATION: Duration = Duration::from_micros(1_000_000 / VIDEO_TARGET_FPS as u64);
+fn frame_duration_from_fps(fps: u32) -> Duration {
+    Duration::from_micros(1_000_000 / u64::from(fps))
+}
 
 /// Helper to convert GStreamer errors to SourceError
 fn gst_error(message: impl Into<String>) -> SourceError {
@@ -51,13 +52,15 @@ impl VideoSource {
         // Initialize GStreamer if not already initialized
         gst::init().map_err(|e| gst_error(format!("GStreamer initialization failed: {}", e)))?;
 
+        let frame_duration = frame_duration_from_fps(config.target_fps());
+
         Ok(Self {
             config,
             pipeline: None,
             appsink: None,
             last_frame: None,
             target_size: None,
-            frame_duration: VIDEO_FRAME_DURATION,
+            frame_duration,
             is_playing: false,
             is_prepared: false,
         })
@@ -100,12 +103,14 @@ impl VideoSource {
             .name("sink")
             .build();
 
+        let target_fps = self.config.target_fps();
+
         // Configure appsink caps for BGRx format.
         let caps = gst::Caps::builder("video/x-raw")
             .field("format", "BGRx")
             .field("width", width as i32)
             .field("height", height as i32)
-            .field("framerate", gst::Fraction::new(VIDEO_TARGET_FPS as i32, 1))
+            .field("framerate", gst::Fraction::new(target_fps as i32, 1))
             .build();
 
         appsink.set_caps(Some(&caps));
@@ -242,12 +247,8 @@ impl VideoSource {
         Ok(())
     }
 
-    /// Check if video has reached end and loop if configured
-    fn check_eos(&mut self) -> Result<(), SourceError> {
-        if !self.config.loop_playback {
-            return Ok(());
-        }
-
+    /// Check non-blocking GStreamer bus messages for diagnostics and EOS handling.
+    fn handle_bus_messages(&mut self) -> Result<(), SourceError> {
         let Some(ref pipeline) = self.pipeline else {
             return Ok(());
         };
@@ -256,20 +257,41 @@ impl VideoSource {
             return Err(gst_error("No bus available"));
         };
 
-        // Check for EOS message (non-blocking)
-        let Some(msg) = bus.pop_filtered(&[gst::MessageType::Eos]) else {
-            return Ok(());
-        };
-
-        if let gst::MessageView::Eos(_) = msg.view() {
-            tracing::debug!("Video reached end, looping");
-            // Seek back to start
-            pipeline
-                .seek_simple(
-                    gst::SeekFlags::FLUSH | gst::SeekFlags::KEY_UNIT,
-                    gst::ClockTime::from_seconds(0),
-                )
-                .ok();
+        while let Some(msg) = bus.pop_filtered(&[
+            gst::MessageType::Error,
+            gst::MessageType::Warning,
+            gst::MessageType::Eos,
+        ]) {
+            match msg.view() {
+                gst::MessageView::Error(error) => {
+                    tracing::error!(
+                        error = %error.error(),
+                        debug = ?error.debug(),
+                        "GStreamer video pipeline error"
+                    );
+                }
+                gst::MessageView::Warning(warning) => {
+                    tracing::warn!(
+                        warning = %warning.error(),
+                        debug = ?warning.debug(),
+                        "GStreamer video pipeline warning"
+                    );
+                }
+                gst::MessageView::Eos(_) => {
+                    if self.config.loop_playback {
+                        tracing::debug!("Video reached end, looping");
+                        pipeline
+                            .seek_simple(
+                                gst::SeekFlags::FLUSH | gst::SeekFlags::KEY_UNIT,
+                                gst::ClockTime::from_seconds(0),
+                            )
+                            .ok();
+                    } else {
+                        tracing::debug!("Video reached end");
+                    }
+                }
+                _ => {}
+            }
         }
 
         Ok(())
@@ -286,11 +308,19 @@ impl WallpaperSource for VideoSource {
             self.play()?;
         }
 
-        // Check for end-of-stream and loop if needed
-        self.check_eos()?;
+        // Check for pipeline diagnostics and end-of-stream handling.
+        self.handle_bus_messages()?;
 
         if let Some(appsink) = self.appsink.as_ref() {
-            if let Some(sample) = appsink.try_pull_sample(gst::ClockTime::ZERO) {
+            let timeout = if self.last_frame.is_some() {
+                gst::ClockTime::ZERO
+            } else {
+                gst::ClockTime::from_mseconds(
+                    self.frame_duration.min(Duration::from_millis(50)).as_millis() as u64,
+                )
+            };
+
+            if let Some(sample) = appsink.try_pull_sample(timeout) {
                 if let Some(frame) = sample_to_frame(&sample, &mut self.last_frame) {
                     self.last_frame = Some(frame);
                 }
@@ -353,10 +383,11 @@ impl WallpaperSource for VideoSource {
 
     fn description(&self) -> String {
         format!(
-            "Video: {} (loop: {}, hw_accel: {})",
+            "Video: {} (loop: {}, hw_accel: {}, fps: {})",
             self.config.path.display(),
             self.config.loop_playback,
-            self.config.hw_accel
+            self.config.hw_accel,
+            self.config.target_fps()
         )
     }
 }
@@ -463,6 +494,33 @@ mod tests {
         assert!(config.loop_playback);
         assert_eq!(config.playback_speed, 1.0);
         assert!(config.hw_accel);
+        assert_eq!(config.fps_limit, None);
+        assert_eq!(config.target_fps(), 60);
+    }
+
+    #[test]
+    fn test_video_config_fps_limit() {
+        let config = VideoConfig {
+            fps_limit: Some(30),
+            ..Default::default()
+        };
+
+        assert_eq!(config.target_fps(), 30);
+    }
+
+    #[test]
+    fn test_video_config_fps_limit_clamps_to_safe_range() {
+        let too_low = VideoConfig {
+            fps_limit: Some(0),
+            ..Default::default()
+        };
+        let too_high = VideoConfig {
+            fps_limit: Some(999),
+            ..Default::default()
+        };
+
+        assert_eq!(too_low.target_fps(), 1);
+        assert_eq!(too_high.target_fps(), 240);
     }
 
     #[test]
@@ -496,5 +554,6 @@ mod tests {
         assert!(desc.contains("Video:"));
         assert!(desc.contains("/tmp/video.mp4"));
         assert!(desc.contains("loop: true"));
+        assert!(desc.contains("fps: 60"));
     }
 }

--- a/src/video.rs
+++ b/src/video.rs
@@ -7,12 +7,41 @@ use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use image::{DynamicImage, ImageBuffer, Rgba};
 use std::{
-    sync::Arc,
+    ffi::OsString,
+    io::Read,
+    path::Path,
+    process::{Child, Command, Stdio},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
 
 fn frame_duration_from_fps(fps: u32) -> Duration {
     Duration::from_micros(1_000_000 / u64::from(fps))
+}
+
+fn frame_duration_from_caps(caps: &gst::CapsRef) -> Option<Duration> {
+    let structure = caps.structure(0)?;
+    let framerate = structure.get::<gst::Fraction>("framerate").ok()?;
+    let numer = framerate.numer();
+    let denom = framerate.denom();
+
+    if numer <= 0 || denom <= 0 {
+        return None;
+    }
+
+    let micros = 1_000_000_u64
+        .checked_mul(denom as u64)?
+        .checked_div(numer as u64)?;
+
+    Some(Duration::from_micros(micros.max(1)))
+}
+
+fn clamp_fps(fps: u32) -> u32 {
+    fps.clamp(1, 240)
 }
 
 /// Helper to convert GStreamer errors to SourceError
@@ -33,12 +62,30 @@ fn link_elements(elements: &[&gst::Element]) -> Result<(), SourceError> {
         .map_err(|e| gst_error(format!("Failed to link elements: {}", e)))
 }
 
+fn video_caps(target_size: Option<(u32, u32)>, fps_limit: Option<u32>) -> gst::Caps {
+    let mut caps = gst::Caps::builder("video/x-raw").field("format", "BGRx");
+
+    if let Some((width, height)) = target_size {
+        caps = caps
+            .field("width", width as i32)
+            .field("height", height as i32);
+    }
+
+    if let Some(fps) = fps_limit {
+        caps = caps.field("framerate", gst::Fraction::new(clamp_fps(fps) as i32, 1));
+    }
+
+    caps.build()
+}
+
 /// Video wallpaper source with GStreamer backend
-#[derive(Debug)]
 pub struct VideoSource {
     config: VideoConfig,
+    backend: VideoBackend,
     pipeline: Option<gst::Pipeline>,
     appsink: Option<gst_app::AppSink>,
+    ffmpeg: Option<FfmpegProcess>,
+    ffmpeg_ended: bool,
     last_frame: Option<FramePayload>,
     target_size: Option<(u32, u32)>,
     frame_duration: Duration,
@@ -56,8 +103,11 @@ impl VideoSource {
 
         Ok(Self {
             config,
+            backend: VideoBackend::GStreamer,
             pipeline: None,
             appsink: None,
+            ffmpeg: None,
+            ffmpeg_ended: false,
             last_frame: None,
             target_size: None,
             frame_duration,
@@ -66,8 +116,29 @@ impl VideoSource {
         })
     }
 
+    fn build_backend(&mut self, target_size: Option<(u32, u32)>) -> Result<(), SourceError> {
+        if should_try_ffmpeg(&self.config.path) {
+            match FfmpegProcess::spawn(&self.config, target_size) {
+                Ok(process) => {
+                    self.frame_duration = process.frame_duration;
+                    self.ffmpeg = Some(process);
+                    self.ffmpeg_ended = false;
+                    self.backend = VideoBackend::Ffmpeg;
+                    tracing::info!(path = %self.config.path.display(), "Using ffmpeg video backend");
+                    return Ok(());
+                }
+                Err(error) => {
+                    tracing::warn!(?error, path = %self.config.path.display(), "Falling back to GStreamer video backend");
+                }
+            }
+        }
+
+        self.backend = VideoBackend::GStreamer;
+        self.build_pipeline(target_size)
+    }
+
     /// Build the GStreamer pipeline for video playback
-    fn build_pipeline(&mut self, width: u32, height: u32) -> Result<(), SourceError> {
+    fn build_pipeline(&mut self, target_size: Option<(u32, u32)>) -> Result<(), SourceError> {
         let path = self.config.path.to_str().ok_or_else(|| gst_error("Invalid video path"))?;
 
         // Detect hardware acceleration capabilities for diagnostics only.
@@ -80,9 +151,12 @@ impl VideoSource {
         let hw_decode = self.config.hw_accel.then(Self::detect_hw_decoder).flatten();
         let decode_element = "decodebin";
 
+        let fps_limit = self.config.fps_limit.map(clamp_fps);
         tracing::info!(
             hw_accel = ?hw_decode,
             decoder = decode_element,
+            playback_rate = if fps_limit.is_some() { "fps_limit" } else { "source_rate" },
+            fps_limit,
             "Building video pipeline"
         );
 
@@ -95,7 +169,15 @@ impl VideoSource {
             .map_err(|e| gst_error(format!("Failed to create filesrc: {}", e)))?;
 
         let decodebin = create_element(decode_element)?;
-        let videorate = create_element("videorate")?;
+        let decode_queue = create_element("queue")?;
+        decode_queue.set_property("max-size-buffers", 4u32);
+        decode_queue.set_property("max-size-bytes", 0u32);
+        decode_queue.set_property("max-size-time", 0u64);
+        let videorate = if fps_limit.is_some() {
+            Some(create_element("videorate")?)
+        } else {
+            None
+        };
         let videoconvert = create_element("videoconvert")?;
         let videoscale = create_element("videoscale")?;
 
@@ -103,21 +185,13 @@ impl VideoSource {
             .name("sink")
             .build();
 
-        let target_fps = self.config.target_fps();
-
         // Configure appsink caps for BGRx format.
-        let caps = gst::Caps::builder("video/x-raw")
-            .field("format", "BGRx")
-            .field("width", width as i32)
-            .field("height", height as i32)
-            .field("framerate", gst::Fraction::new(target_fps as i32, 1))
-            .build();
+        let caps = video_caps(target_size, self.config.fps_limit);
 
         appsink.set_caps(Some(&caps));
-        // Keep only the latest frame. Video wallpapers redraw from the most
-        // recent frame, so queueing old frames just adds latency and memory
-        // pressure when the compositor cannot consume at the source framerate.
-        appsink.set_property("max-buffers", 1u32);
+        // Keep a tiny sink queue so near-ready frames are not discarded before
+        // compositor-driven pulls, without accumulating meaningful latency.
+        appsink.set_property("max-buffers", 2u32);
         appsink.set_property("drop", true);
         // We pull frames on demand from next_frame(), so keep appsink unsynced
         // to avoid introducing a second pacing clock besides compositor frames.
@@ -128,27 +202,47 @@ impl VideoSource {
             .add_many([
                 &filesrc,
                 &decodebin,
-                &videorate,
+                &decode_queue,
                 &videoconvert,
                 &videoscale,
                 appsink.upcast_ref(),
             ])
             .map_err(|e| gst_error(format!("Failed to add elements to pipeline: {}", e)))?;
+        if let Some(videorate) = videorate.as_ref() {
+            pipeline
+                .add(videorate)
+                .map_err(|e| gst_error(format!("Failed to add videorate to pipeline: {}", e)))?;
+        }
 
         // Link static elements
         link_elements(&[&filesrc, &decodebin])?;
-        link_elements(&[&videorate, &videoconvert, &videoscale, appsink.upcast_ref()])?;
+        if let Some(videorate) = videorate.as_ref() {
+            link_elements(&[
+                &decode_queue,
+                videorate,
+                &videoconvert,
+                &videoscale,
+                appsink.upcast_ref(),
+            ])?;
+        } else {
+            link_elements(&[
+                &decode_queue,
+                &videoconvert,
+                &videoscale,
+                appsink.upcast_ref(),
+            ])?;
+        }
 
         // Handle dynamic pad linking from decodebin
-        let videorate_weak = videorate.downgrade();
+        let video_pad_target = decode_queue.downgrade();
         decodebin.connect_pad_added(move |_src, src_pad| {
-            let Some(videorate) = videorate_weak.upgrade() else {
+            let Some(video_pad_target) = video_pad_target.upgrade() else {
                 return;
             };
 
-            let sink_pad = videorate
+            let sink_pad = video_pad_target
                 .static_pad("sink")
-                .expect("videorate has no sink pad");
+                .expect("video pad target has no sink pad");
 
             if sink_pad.is_linked() {
                 return;
@@ -221,6 +315,11 @@ impl VideoSource {
 
     /// Start video playback
     fn play(&mut self) -> Result<(), SourceError> {
+        if matches!(self.backend, VideoBackend::Ffmpeg) {
+            self.is_playing = true;
+            return Ok(());
+        }
+
         if let Some(ref pipeline) = self.pipeline {
             pipeline
                 .set_state(gst::State::Playing)
@@ -296,6 +395,54 @@ impl VideoSource {
 
         Ok(())
     }
+
+    fn next_ffmpeg_frame(&mut self) -> Option<FramePayload> {
+        let Some(process) = self.ffmpeg.as_mut() else {
+            return None;
+        };
+
+        let mut respawn_target = None;
+        let latest = process.latest_frame.lock().ok().and_then(|mut frame| {
+            frame.take().map(|data| FramePayload::Bgrx {
+                data,
+                width: process.width,
+                height: process.height,
+                stride: process.stride,
+            })
+        });
+
+        if process.ended.load(Ordering::Acquire) {
+            if self.config.loop_playback {
+                tracing::warn!(path = %self.config.path.display(), "ffmpeg video reader ended unexpectedly; respawning");
+                respawn_target = Some(process.target_size);
+            } else {
+                tracing::debug!(path = %self.config.path.display(), "ffmpeg video reached end");
+                self.ffmpeg_ended = true;
+                self.last_frame = None;
+                self.ffmpeg = None;
+                return None;
+            }
+        }
+
+        if let Some(target_size) = respawn_target {
+            match FfmpegProcess::spawn(&self.config, target_size) {
+                Ok(restarted) => {
+                    self.frame_duration = restarted.frame_duration;
+                    self.ffmpeg = Some(restarted);
+                    self.ffmpeg_ended = false;
+                }
+                Err(error) => {
+                    tracing::error!(?error, path = %self.config.path.display(), "Failed to respawn ffmpeg video backend");
+                    self.ffmpeg_ended = true;
+                    self.last_frame = None;
+                    self.ffmpeg = None;
+                    return None;
+                }
+            }
+        }
+
+        latest
+    }
 }
 
 impl WallpaperSource for VideoSource {
@@ -308,21 +455,37 @@ impl WallpaperSource for VideoSource {
             self.play()?;
         }
 
-        // Check for pipeline diagnostics and end-of-stream handling.
-        self.handle_bus_messages()?;
+        if self.ffmpeg_ended {
+            self.last_frame = None;
+        } else if matches!(self.backend, VideoBackend::Ffmpeg) {
+            if let Some(frame) = self.next_ffmpeg_frame() {
+                self.last_frame = Some(frame);
+            }
+        } else {
+            // Check for pipeline diagnostics and end-of-stream handling.
+            self.handle_bus_messages()?;
 
-        if let Some(appsink) = self.appsink.as_ref() {
-            let timeout = if self.last_frame.is_some() {
-                gst::ClockTime::ZERO
-            } else {
-                gst::ClockTime::from_mseconds(
-                    self.frame_duration.min(Duration::from_millis(50)).as_millis() as u64,
-                )
-            };
+            if let Some(appsink) = self.appsink.as_ref() {
+                let timeout = if self.last_frame.is_some() {
+                    gst::ClockTime::from_mseconds(3)
+                } else {
+                    gst::ClockTime::from_mseconds(
+                        self.frame_duration.min(Duration::from_millis(50)).as_millis() as u64,
+                    )
+                };
 
-            if let Some(sample) = appsink.try_pull_sample(timeout) {
-                if let Some(frame) = sample_to_frame(&sample, &mut self.last_frame) {
-                    self.last_frame = Some(frame);
+                if let Some(sample) = appsink.try_pull_sample(timeout) {
+                    if self.config.fps_limit.is_none() {
+                        if let Some(caps) = sample.caps() {
+                            if let Some(frame_duration) = frame_duration_from_caps(caps) {
+                                self.frame_duration = frame_duration;
+                            }
+                        }
+                    }
+
+                    if let Some(frame) = sample_to_frame(&sample, &mut self.last_frame) {
+                        self.last_frame = Some(frame);
+                    }
                 }
             }
         }
@@ -334,15 +497,15 @@ impl WallpaperSource for VideoSource {
             Ok(Frame {
                 payload: payload.clone(),
                 timestamp: Instant::now(),
+                is_placeholder: false,
             })
         } else {
             // No frame yet, return black frame
             let (width, height) = self.target_size.unwrap_or(crate::source::FALLBACK_RESOLUTION);
             let black = ImageBuffer::from_pixel(width, height, Rgba([0, 0, 0, 255]));
-            Ok(Frame {
-                payload: FramePayload::Image(Arc::new(DynamicImage::ImageRgba8(black))),
-                timestamp: Instant::now(),
-            })
+            Ok(Frame::placeholder(FramePayload::Image(Arc::new(
+                DynamicImage::ImageRgba8(black),
+            ))))
         }
     }
 
@@ -357,9 +520,20 @@ impl WallpaperSource for VideoSource {
     fn prepare(&mut self, width: u32, height: u32) -> Result<(), SourceError> {
         self.target_size = Some((width, height));
 
-        // Build pipeline if not already built
-        if self.pipeline.is_none() {
-            self.build_pipeline(width, height)?;
+        // Build backend if not already built
+        if self.pipeline.is_none() && self.ffmpeg.is_none() {
+            self.build_backend(Some((width, height)))?;
+        }
+
+        self.is_prepared = true;
+        Ok(())
+    }
+
+    fn prepare_unscaled(&mut self) -> Result<(), SourceError> {
+        self.target_size = Some(crate::source::FALLBACK_RESOLUTION);
+
+        if self.pipeline.is_none() && self.ffmpeg.is_none() {
+            self.build_backend(None)?;
         }
 
         self.is_prepared = true;
@@ -374,7 +548,10 @@ impl WallpaperSource for VideoSource {
 
         self.pipeline = None;
         self.appsink = None;
+        self.ffmpeg = None;
+        self.ffmpeg_ended = false;
         self.last_frame = None;
+        self.backend = VideoBackend::GStreamer;
         self.is_playing = false;
         self.is_prepared = false;
 
@@ -389,6 +566,327 @@ impl WallpaperSource for VideoSource {
             self.config.hw_accel,
             self.config.target_fps()
         )
+    }
+}
+
+impl std::fmt::Debug for VideoSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VideoSource")
+            .field("config", &self.config)
+            .field("backend", &self.backend)
+            .field("ffmpeg_ended", &self.ffmpeg_ended)
+            .field("target_size", &self.target_size)
+            .field("frame_duration", &self.frame_duration)
+            .field("is_playing", &self.is_playing)
+            .field("is_prepared", &self.is_prepared)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VideoBackend {
+    GStreamer,
+    Ffmpeg,
+}
+
+struct FfmpegProcess {
+    width: u32,
+    height: u32,
+    stride: usize,
+    target_size: Option<(u32, u32)>,
+    frame_duration: Duration,
+    latest_frame: Arc<Mutex<Option<Arc<[u8]>>>>,
+    ended: Arc<AtomicBool>,
+    child: Child,
+    reader: Option<JoinHandle<()>>,
+}
+
+impl FfmpegProcess {
+    fn spawn(config: &VideoConfig, target_size: Option<(u32, u32)>) -> Result<Self, SourceError> {
+        let metadata = probe_video(&config.path)?;
+        let (width, height) = target_size.unwrap_or((metadata.width, metadata.height));
+        let stride = width as usize * 4;
+        let frame_size = stride
+            .checked_mul(height as usize)
+            .ok_or_else(|| gst_error("ffmpeg frame dimensions overflow"))?;
+        let args = ffmpeg_args(config, target_size);
+
+        let mut child = Command::new("ffmpeg")
+            .args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| gst_error(format!("Failed to spawn ffmpeg: {}", e)))?;
+
+        let Some(stdout) = child.stdout.take() else {
+            kill_and_wait(&mut child);
+            return Err(gst_error("ffmpeg stdout was not piped"));
+        };
+        let latest_frame = Arc::new(Mutex::new(None));
+        let ended = Arc::new(AtomicBool::new(false));
+        let reader_latest_frame = Arc::clone(&latest_frame);
+        let reader_ended = Arc::clone(&ended);
+        let reader = match thread::Builder::new()
+            .name("cosmic-ext-bg-ffmpeg-reader".to_string())
+            .spawn(move || read_ffmpeg_frames(stdout, frame_size, reader_latest_frame, reader_ended))
+        {
+            Ok(reader) => reader,
+            Err(error) => {
+                kill_and_wait(&mut child);
+                return Err(gst_error(format!(
+                    "Failed to start ffmpeg reader thread: {}",
+                    error
+                )));
+            }
+        };
+
+        Ok(Self {
+            width,
+            height,
+            stride,
+            target_size,
+            frame_duration: adjusted_frame_duration(config, metadata.frame_duration),
+            latest_frame,
+            ended,
+            child,
+            reader: Some(reader),
+        })
+    }
+}
+
+fn kill_and_wait(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+impl Drop for FfmpegProcess {
+    fn drop(&mut self) {
+        kill_and_wait(&mut self.child);
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct VideoMetadata {
+    width: u32,
+    height: u32,
+    frame_duration: Duration,
+}
+
+fn should_try_ffmpeg(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("mp4"))
+}
+
+fn ffmpeg_args(config: &VideoConfig, target_size: Option<(u32, u32)>) -> Vec<OsString> {
+    let mut args = vec![
+        OsString::from("-nostdin"),
+        OsString::from("-hide_banner"),
+        OsString::from("-loglevel"),
+        OsString::from("error"),
+    ];
+
+    if config.loop_playback {
+        args.extend([OsString::from("-stream_loop"), OsString::from("-1")]);
+    }
+
+    args.extend([OsString::from("-re"), OsString::from("-i")]);
+    args.push(config.path.as_os_str().to_os_string());
+
+    if config.fps_limit.is_some() || target_size.is_some() {
+        args.extend([
+            OsString::from("-vf"),
+            OsString::from(ffmpeg_filter(config.fps_limit, target_size)),
+        ]);
+    }
+
+    args.extend([
+        OsString::from("-an"),
+        OsString::from("-f"),
+        OsString::from("rawvideo"),
+        OsString::from("-pix_fmt"),
+        OsString::from("bgr0"),
+        OsString::from("pipe:1"),
+    ]);
+
+    args
+}
+
+fn ffmpeg_filter(fps_limit: Option<u32>, target_size: Option<(u32, u32)>) -> String {
+    let mut filters = Vec::new();
+    if let Some(fps) = fps_limit {
+        filters.push(format!("fps={}", clamp_fps(fps)));
+    }
+    if let Some((width, height)) = target_size {
+        filters.push(format!("scale={}:{}", width, height));
+    }
+    filters.join(",")
+}
+
+fn probe_video(path: &Path) -> Result<VideoMetadata, SourceError> {
+    let output = Command::new("ffprobe")
+        .args([
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=width,height,r_frame_rate",
+            "-of",
+            "default=noprint_wrappers=1",
+        ])
+        .arg(path)
+        .output()
+        .map_err(|e| gst_error(format!("Failed to run ffprobe: {}", e)))?;
+
+    if !output.status.success() {
+        return Err(gst_error(format!(
+            "ffprobe failed for {} with status {}",
+            path.display(),
+            output.status
+        )));
+    }
+
+    parse_ffprobe_output(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_ffprobe_output(output: &str) -> Result<VideoMetadata, SourceError> {
+    let mut width = None;
+    let mut height = None;
+    let mut frame_duration = None;
+
+    for line in output.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+
+        match key {
+            "width" => width = value.parse::<u32>().ok(),
+            "height" => height = value.parse::<u32>().ok(),
+            "r_frame_rate" => frame_duration = parse_frame_duration_fraction(value),
+            _ => {}
+        }
+    }
+
+    let width = width.ok_or_else(|| gst_error("ffprobe did not report video width"))?;
+    let height = height.ok_or_else(|| gst_error("ffprobe did not report video height"))?;
+    let frame_duration = frame_duration.unwrap_or_else(|| frame_duration_from_fps(60));
+
+    if width == 0 || height == 0 {
+        return Err(gst_error("ffprobe reported invalid video dimensions"));
+    }
+
+    Ok(VideoMetadata {
+        width,
+        height,
+        frame_duration,
+    })
+}
+
+fn parse_frame_duration_fraction(value: &str) -> Option<Duration> {
+    let (numer, denom) = value.split_once('/')?;
+    let numer = numer.parse::<u64>().ok()?;
+    let denom = denom.parse::<u64>().ok()?;
+    if numer == 0 || denom == 0 {
+        return None;
+    }
+
+    let micros = 1_000_000_u64.checked_mul(denom)?.checked_div(numer)?;
+    Some(Duration::from_micros(micros.max(1)))
+}
+
+fn adjusted_frame_duration(config: &VideoConfig, source_frame_duration: Duration) -> Duration {
+    let base = config
+        .fps_limit
+        .map(clamp_fps)
+        .map(frame_duration_from_fps)
+        .unwrap_or(source_frame_duration);
+    let speed = config.clamped_speed();
+    Duration::from_secs_f64((base.as_secs_f64() / speed).max(0.001))
+}
+
+fn read_ffmpeg_frames(
+    mut stdout: impl Read,
+    frame_size: usize,
+    latest_frame: Arc<Mutex<Option<Arc<[u8]>>>>,
+    ended: Arc<AtomicBool>,
+) {
+    loop {
+        let mut frame = vec![0; frame_size];
+        if stdout.read_exact(&mut frame).is_err() {
+            break;
+        }
+        let Ok(mut latest) = latest_frame.lock() else {
+            break;
+        };
+        *latest = Some(Arc::<[u8]>::from(frame));
+    }
+    ended.store(true, Ordering::Release);
+}
+
+#[cfg(test)]
+fn read_ffmpeg_frames_for_test(frames: &[&[u8]], frame_size: usize) -> Option<Vec<u8>> {
+    let latest_frame = Arc::new(Mutex::new(None));
+    let ended = Arc::new(AtomicBool::new(false));
+    let mut bytes = Vec::new();
+    for frame in frames {
+        bytes.extend_from_slice(frame);
+    }
+
+    read_ffmpeg_frames(&bytes[..], frame_size, Arc::clone(&latest_frame), ended);
+
+    latest_frame
+        .lock()
+        .ok()
+        .and_then(|frame| frame.as_ref().map(|frame| frame.to_vec()))
+}
+
+#[cfg(test)]
+fn os_args_contain_pair(args: &[OsString], name: &str, value: &str) -> bool {
+    args.windows(2).any(|window| {
+        window[0].as_os_str() == name && window[1].as_os_str() == value
+    })
+}
+
+#[cfg(test)]
+fn os_args_contain(args: &[OsString], value: &str) -> bool {
+    args.iter().any(|arg| arg.as_os_str() == value)
+}
+
+#[cfg(test)]
+fn os_args_position(args: &[OsString], value: &str) -> Option<usize> {
+    args.iter().position(|arg| arg.as_os_str() == value)
+}
+
+#[cfg(test)]
+fn os_args_last(args: &[OsString]) -> Option<&str> {
+    args.last().and_then(|arg| arg.to_str())
+}
+
+#[cfg(test)]
+fn take_ffmpeg_frame_for_test(source: &mut VideoSource) -> Option<FramePayload> {
+    source.next_ffmpeg_frame()
+}
+
+#[cfg(test)]
+fn test_ffmpeg_process(
+    config: &VideoConfig,
+    latest_frame: Arc<Mutex<Option<Arc<[u8]>>>>,
+    ended: Arc<AtomicBool>,
+) -> FfmpegProcess {
+    FfmpegProcess {
+        width: 1,
+        height: 1,
+        stride: 4,
+        target_size: Some((1, 1)),
+        frame_duration: adjusted_frame_duration(config, frame_duration_from_fps(60)),
+        latest_frame,
+        ended,
+        child: Command::new("true").spawn().unwrap(),
+        reader: None,
     }
 }
 
@@ -555,5 +1053,200 @@ mod tests {
         assert!(desc.contains("/tmp/video.mp4"));
         assert!(desc.contains("loop: true"));
         assert!(desc.contains("fps: 60"));
+    }
+
+    #[test]
+    fn test_source_rate_caps_omit_framerate() {
+        gst::init().unwrap();
+
+        let caps = video_caps(Some((1920, 1080)), None);
+        let structure = caps.structure(0).unwrap();
+
+        assert_eq!(structure.get::<&str>("format").unwrap(), "BGRx");
+        assert_eq!(structure.get::<i32>("width").unwrap(), 1920);
+        assert_eq!(structure.get::<i32>("height").unwrap(), 1080);
+        assert!(structure.get::<gst::Fraction>("framerate").is_err());
+    }
+
+    #[test]
+    fn test_fps_limited_caps_include_clamped_framerate() {
+        gst::init().unwrap();
+
+        let caps = video_caps(None, Some(999));
+        let structure = caps.structure(0).unwrap();
+
+        assert_eq!(structure.get::<&str>("format").unwrap(), "BGRx");
+        assert!(structure.get::<i32>("width").is_err());
+        assert!(structure.get::<i32>("height").is_err());
+        assert_eq!(
+            structure.get::<gst::Fraction>("framerate").unwrap(),
+            gst::Fraction::new(240, 1)
+        );
+    }
+
+    #[test]
+    fn test_frame_duration_from_caps_uses_source_framerate() {
+        gst::init().unwrap();
+
+        let caps = gst::Caps::builder("video/x-raw")
+            .field("framerate", gst::Fraction::new(24, 1))
+            .build();
+
+        assert_eq!(
+            frame_duration_from_caps(&caps),
+            Some(Duration::from_micros(41_666))
+        );
+    }
+
+    #[test]
+    fn test_frame_duration_from_caps_ignores_missing_framerate() {
+        gst::init().unwrap();
+
+        let caps = gst::Caps::builder("video/x-raw").build();
+
+        assert_eq!(frame_duration_from_caps(&caps), None);
+    }
+
+    #[test]
+    fn test_should_try_ffmpeg_only_for_mp4() {
+        assert!(should_try_ffmpeg(Path::new("/tmp/wallpaper.MP4")));
+        assert!(!should_try_ffmpeg(Path::new("/tmp/wallpaper.webm")));
+        assert!(!should_try_ffmpeg(Path::new("/tmp/wallpaper")));
+    }
+
+    #[test]
+    fn test_ffmpeg_args_loop_scaled_fps_limited_bgrx_pipe() {
+        let config = VideoConfig {
+            path: PathBuf::from("/tmp/video.mp4"),
+            loop_playback: true,
+            fps_limit: Some(999),
+            ..Default::default()
+        };
+
+        let args = ffmpeg_args(&config, Some((1920, 1080)));
+
+        assert_eq!(args[0].as_os_str(), "-nostdin");
+        assert!(os_args_contain_pair(&args, "-stream_loop", "-1"));
+        assert!(os_args_contain_pair(&args, "-vf", "fps=240,scale=1920:1080"));
+        assert!(os_args_contain_pair(&args, "-pix_fmt", "bgr0"));
+        assert_eq!(os_args_last(&args), Some("pipe:1"));
+    }
+
+    #[test]
+    fn test_ffmpeg_args_realtime_before_input_and_preserve_path_os_string() {
+        let path = PathBuf::from("/tmp/video.mp4");
+        let config = VideoConfig {
+            path: path.clone(),
+            loop_playback: false,
+            ..Default::default()
+        };
+
+        let args = ffmpeg_args(&config, None);
+        let re_index = os_args_position(&args, "-re").unwrap();
+        let input_index = os_args_position(&args, "-i").unwrap();
+
+        assert!(re_index < input_index);
+        assert_eq!(args.get(input_index + 1).map(OsString::as_os_str), Some(path.as_os_str()));
+    }
+
+    #[test]
+    fn test_ffmpeg_args_omit_loop_and_filter_when_unlimited_unscaled() {
+        let config = VideoConfig {
+            path: PathBuf::from("/tmp/video.mp4"),
+            loop_playback: false,
+            fps_limit: None,
+            ..Default::default()
+        };
+
+        let args = ffmpeg_args(&config, None);
+
+        assert!(!os_args_contain(&args, "-stream_loop"));
+        assert!(!os_args_contain(&args, "-vf"));
+        assert!(os_args_contain(&args, "-re"));
+    }
+
+    #[test]
+    fn test_parse_ffprobe_output_uses_keyed_metadata() {
+        let metadata = parse_ffprobe_output("width=3840\nheight=2160\nr_frame_rate=24/1\n").unwrap();
+
+        assert_eq!(metadata.width, 3840);
+        assert_eq!(metadata.height, 2160);
+        assert_eq!(metadata.frame_duration, Duration::from_micros(41_666));
+    }
+
+    #[test]
+    fn test_adjusted_frame_duration_uses_fps_limit_and_speed() {
+        let config = VideoConfig {
+            fps_limit: Some(30),
+            playback_speed: 2.0,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            adjusted_frame_duration(&config, Duration::from_millis(100)),
+            Duration::from_nanos(16_666_500)
+        );
+    }
+
+    #[test]
+    fn test_ffmpeg_reader_keeps_latest_frame() {
+        let latest = read_ffmpeg_frames_for_test(&[b"old1", b"new2", b"last"], 4).unwrap();
+
+        assert_eq!(latest, b"last");
+    }
+
+    #[test]
+    fn test_ffmpeg_non_loop_eof_clears_stale_frame_and_marks_ended() {
+        let latest_frame = Arc::new(Mutex::new(Some(Arc::<[u8]>::from(&b"done"[..]))));
+        let ended = Arc::new(AtomicBool::new(true));
+        let config = VideoConfig {
+            path: PathBuf::from("/tmp/video.mp4"),
+            loop_playback: false,
+            ..Default::default()
+        };
+        let process = test_ffmpeg_process(&config, latest_frame, ended);
+        let mut source = VideoSource::new(config).unwrap();
+        source.backend = VideoBackend::Ffmpeg;
+        source.ffmpeg = Some(process);
+        source.last_frame = Some(FramePayload::Bgrx {
+            data: Arc::<[u8]>::from(&b"stale"[..]),
+            width: 1,
+            height: 1,
+            stride: 4,
+        });
+
+        assert!(take_ffmpeg_frame_for_test(&mut source).is_none());
+        assert!(source.ffmpeg_ended);
+        assert!(source.ffmpeg.is_none());
+        assert!(source.last_frame.is_none());
+    }
+
+    #[test]
+    fn test_ffmpeg_loop_respawn_failure_marks_ended() {
+        let latest_frame = Arc::new(Mutex::new(Some(Arc::<[u8]>::from(&b"done"[..]))));
+        let ended = Arc::new(AtomicBool::new(true));
+        let config = VideoConfig {
+            path: PathBuf::from("/tmp/cosmic-ext-bg-missing-respawn-test.mp4"),
+            loop_playback: true,
+            ..Default::default()
+        };
+        let process = test_ffmpeg_process(&config, latest_frame, ended);
+        let mut source = VideoSource::new(config).unwrap();
+        source.backend = VideoBackend::Ffmpeg;
+        source.ffmpeg = Some(process);
+        source.last_frame = Some(FramePayload::Bgrx {
+            data: Arc::<[u8]>::from(&b"stale"[..]),
+            width: 1,
+            height: 1,
+            stride: 4,
+        });
+
+        assert!(take_ffmpeg_frame_for_test(&mut source).is_none());
+        assert!(source.ffmpeg_ended);
+        assert!(source.ffmpeg.is_none());
+        assert!(source.last_frame.is_none());
+
+        assert!(take_ffmpeg_frame_for_test(&mut source).is_none());
+        assert!(source.ffmpeg.is_none());
     }
 }

--- a/src/video.rs
+++ b/src/video.rs
@@ -291,7 +291,7 @@ impl WallpaperSource for VideoSource {
 
         if let Some(appsink) = self.appsink.as_ref() {
             if let Some(sample) = appsink.try_pull_sample(gst::ClockTime::ZERO) {
-                if let Some(frame) = sample_to_frame(&sample) {
+                if let Some(frame) = sample_to_frame(&sample, &mut self.last_frame) {
                     self.last_frame = Some(frame);
                 }
             }
@@ -361,7 +361,10 @@ impl WallpaperSource for VideoSource {
     }
 }
 
-fn sample_to_frame(sample: &gst::Sample) -> Option<FramePayload> {
+fn sample_to_frame(
+    sample: &gst::Sample,
+    reusable_frame: &mut Option<FramePayload>,
+) -> Option<FramePayload> {
     let buffer = sample.buffer()?;
     let map = buffer.map_readable().ok()?;
     let caps = sample.caps()?;
@@ -369,14 +372,33 @@ fn sample_to_frame(sample: &gst::Sample) -> Option<FramePayload> {
 
     let width = structure.get::<i32>("width").ok()? as u32;
     let height = structure.get::<i32>("height").ok()? as u32;
-    let stride = structure.get::<i32>("stride").ok().map(|s| s as usize).unwrap_or(width as usize * 4);
+    let stride = structure
+        .get::<i32>("stride")
+        .ok()
+        .map(|s| s as usize)
+        .unwrap_or(width as usize * 4);
     let frame_size = stride.checked_mul(height as usize)?;
 
     if map.as_slice().len() < frame_size {
         return None;
     }
 
-    let raw = Arc::<[u8]>::from(map.as_slice()[..frame_size].to_vec());
+    let source = &map.as_slice()[..frame_size];
+
+    let raw = match reusable_frame.take() {
+        Some(FramePayload::Bgrx { mut data, .. }) if data.len() == frame_size => {
+            if let Some(bytes) = Arc::get_mut(&mut data) {
+                bytes.copy_from_slice(source);
+                data
+            } else {
+                Arc::<[u8]>::from(source.to_vec())
+            }
+        }
+        frame => {
+            *reusable_frame = frame;
+            Arc::<[u8]>::from(source.to_vec())
+        }
+    };
 
     Some(FramePayload::Bgrx {
         data: raw,
@@ -388,7 +410,7 @@ fn sample_to_frame(sample: &gst::Sample) -> Option<FramePayload> {
 
 #[allow(dead_code)]
 fn sample_to_image(sample: &gst::Sample) -> Option<Arc<DynamicImage>> {
-    let payload = sample_to_frame(sample)?;
+    let payload = sample_to_frame(sample, &mut None)?;
     let FramePayload::Bgrx {
         data,
         width,

--- a/src/video.rs
+++ b/src/video.rs
@@ -814,6 +814,17 @@ fn adjusted_frame_duration(config: &VideoConfig, source_frame_duration: Duration
     Duration::from_secs_f64((base.as_secs_f64() / speed).max(0.001))
 }
 
+/// Returns a uniquely-owned, writable view into `slot`, recycling its existing
+/// allocation when no other reference is alive. When a consumer still holds the
+/// previous frame (the published clone has not been dropped yet) the buffer is
+/// replaced with a fresh allocation so we never clobber data still being read.
+fn writable_frame_buffer(slot: &mut Arc<[u8]>, frame_size: usize) -> &mut [u8] {
+    if Arc::get_mut(slot).is_none() {
+        *slot = Arc::from(vec![0u8; frame_size]);
+    }
+    Arc::get_mut(slot).expect("freshly created Arc is uniquely owned")
+}
+
 fn read_ffmpeg_frames(
     mut stdout: impl Read,
     frame_size: usize,
@@ -822,9 +833,14 @@ fn read_ffmpeg_frames(
 ) {
     let mut produced: u64 = 0;
     let mut window_start = Instant::now();
+    // Reusable frame buffer. We publish a *clone* of `slot` so the producer keeps
+    // ownership; on the next iteration `writable_frame_buffer` writes straight back
+    // into it whenever no consumer still references it. For a 4K frame this avoids a
+    // fresh ~33MB allocation + zero-fill + copy per frame (glibc mmap/munmap churn).
+    let mut slot: Arc<[u8]> = Arc::from(vec![0u8; frame_size]);
     loop {
-        let mut frame = vec![0; frame_size];
-        if stdout.read_exact(&mut frame).is_err() {
+        let writable = writable_frame_buffer(&mut slot, frame_size);
+        if stdout.read_exact(writable).is_err() {
             break;
         }
         produced += 1;
@@ -844,7 +860,9 @@ fn read_ffmpeg_frames(
         let Ok(mut latest) = latest_frame.lock() else {
             break;
         };
-        *latest = Some(Arc::<[u8]>::from(frame));
+        // Cheap publish: bumps the refcount, no data copy. Retaining `slot` lets the
+        // next iteration recycle this allocation once readers drop their clones.
+        *latest = Some(Arc::clone(&slot));
     }
     ended.store(true, Ordering::Release);
 }
@@ -1215,6 +1233,32 @@ mod tests {
         let latest = read_ffmpeg_frames_for_test(&[b"old1", b"new2", b"last"], 4).unwrap();
 
         assert_eq!(latest, b"last");
+    }
+
+    #[test]
+    fn writable_frame_buffer_recycles_when_unique() {
+        let mut slot: Arc<[u8]> = Arc::from(vec![0u8; 4]);
+        let ptr_before = slot.as_ptr();
+
+        writable_frame_buffer(&mut slot, 4).copy_from_slice(b"abcd");
+
+        // No other reference alive -> same allocation is reused (no churn).
+        assert_eq!(slot.as_ptr(), ptr_before);
+        assert_eq!(&*slot, b"abcd");
+    }
+
+    #[test]
+    fn writable_frame_buffer_allocates_when_shared() {
+        let mut slot: Arc<[u8]> = Arc::from(vec![1u8; 4]);
+        let held = Arc::clone(&slot); // simulate a consumer still holding the frame
+        let ptr_before = slot.as_ptr();
+
+        writable_frame_buffer(&mut slot, 4).copy_from_slice(b"wxyz");
+
+        // Shared -> a fresh buffer is allocated and the held frame is left intact.
+        assert_ne!(slot.as_ptr(), ptr_before);
+        assert_eq!(&*held, &[1u8; 4]);
+        assert_eq!(&*slot, b"wxyz");
     }
 
     #[test]

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -339,6 +339,9 @@ impl Wallpaper {
         }
 
         let mut video_frame = None;
+        // Per-stage timing marks for video, used to attribute stutter to decode
+        // (frame pull) vs render (compose + buffer + commit). None for images.
+        let mut t_pulled = None;
         if matches!(self.entry.source, Source::Video(_)) {
             if let Some(animated_source) = self.animated_source.as_mut() {
                 match &self.entry.scaling_mode {
@@ -358,6 +361,7 @@ impl Wallpaper {
                         reason: format!("Failed to get next frame: {}", e),
                     })?;
                 video_frame = Some(frame);
+                t_pulled = Some(Instant::now());
             }
         }
 
@@ -366,6 +370,7 @@ impl Wallpaper {
                 self.prepare_video_frame(frame.payload, frame.is_placeholder, width, height)
             })
             .transpose()?;
+        let t_prepared = t_pulled.map(|_| Instant::now());
 
         // Now we can get mutable access to the layer
         let layer = self.layers.get_mut(layer_idx).ok_or(DrawError::NoSource)?;
@@ -411,6 +416,8 @@ impl Wallpaper {
             crate::draw::canvas(pool, image, width as i32, height as i32, width as i32 * 4)?
         };
 
+        let t_buffer = t_pulled.map(|_| Instant::now());
+
         crate::draw::layer_surface(
             layer,
             &self.queue_handle,
@@ -420,8 +427,23 @@ impl Wallpaper {
 
         layer.needs_redraw = false;
 
-        let elapsed = Instant::now().duration_since(start);
-        tracing::debug!(?elapsed, source = ?self.entry.source, "wallpaper draw");
+        let end = Instant::now();
+        let elapsed = end.duration_since(start);
+        if let (Some(pulled), Some(prepared), Some(buffer_done)) = (t_pulled, t_prepared, t_buffer) {
+            let ms = |d: std::time::Duration| d.as_secs_f64() * 1000.0;
+            tracing::debug!(
+                total_ms = ms(elapsed),
+                pull_ms = ms(pulled.duration_since(start)),
+                prepare_ms = ms(prepared.duration_since(pulled)),
+                buffer_ms = ms(buffer_done.duration_since(prepared)),
+                commit_ms = ms(end.duration_since(buffer_done)),
+                layer = ?(width, height),
+                scaling = ?self.entry.scaling_mode,
+                "video frame timing"
+            );
+        } else {
+            tracing::debug!(?elapsed, source = ?self.entry.source, "wallpaper draw");
+        }
 
         Ok(())
     }

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -3,13 +3,14 @@
 use crate::{CosmicBg, CosmicBgLayer};
 use crate::animated::AnimatedSource;
 use crate::shader::ShaderSource;
-use crate::source::WallpaperSource;
+use crate::source::{FramePayload, WallpaperSource};
 use crate::video::VideoSource;
 
 use std::{
     collections::VecDeque,
     fs::{self, File},
     path::{Path, PathBuf},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -26,8 +27,9 @@ use sctk::{
             self, RegistrationToken,
             timer::{TimeoutAction, Timer},
         },
-        client::QueueHandle,
+        client::{QueueHandle, protocol::wl_surface},
     },
+    shell::WaylandSurface,
     shm::slot::CreateBufferError,
 };
 use thiserror::Error;
@@ -197,7 +199,7 @@ impl Wallpaper {
 
     pub fn draw(&mut self) {
         let start = Instant::now();
-        let mut cur_resized_img: Option<DynamicImage> = None;
+        let mut cur_resized_img: Option<Arc<DynamicImage>> = None;
 
         // Use indices to avoid borrow conflicts with self
         let layer_indices: Vec<usize> = self.layers
@@ -220,10 +222,28 @@ impl Wallpaper {
         }
     }
 
+    pub fn draw_video_frame_for_surface(&mut self, surface: &wl_surface::WlSurface) -> bool {
+        if !matches!(self.entry.source, Source::Video(_)) {
+            return false;
+        }
+
+        let Some(layer) = self
+            .layers
+            .iter_mut()
+            .find(|layer| layer.layer.wl_surface() == surface)
+        else {
+            return false;
+        };
+
+        layer.needs_redraw = true;
+        self.draw();
+        true
+    }
+
     fn draw_layer_by_index(
         &mut self,
         layer_idx: usize,
-        cur_resized_img: &mut Option<DynamicImage>,
+        cur_resized_img: &mut Option<Arc<DynamicImage>>,
         start: Instant,
     ) -> Result<(), DrawError> {
         // Calculate dimensions first (immutable borrow)
@@ -232,21 +252,55 @@ impl Wallpaper {
             self.calculate_layer_dimensions(layer)?
         };
 
-        let needs_new_image = cur_resized_img
-            .as_ref()
-            .map_or(true, |img| img.width() != width || img.height() != height);
+        if !matches!(self.entry.source, Source::Video(_)) {
+            let needs_new_image = cur_resized_img
+                .as_ref()
+                .map_or(true, |img| img.width() != width || img.height() != height);
 
-        if needs_new_image {
-            *cur_resized_img = Some(self.prepare_scaled_image(width, height)?);
+            if needs_new_image {
+                *cur_resized_img = Some(self.prepare_scaled_image(width, height)?);
+            }
+        }
+
+        let mut video_payload = None;
+        if matches!(self.entry.source, Source::Video(_)) {
+            if let Some(animated_source) = self.animated_source.as_mut() {
+                animated_source.prepare(width, height)
+                    .map_err(|e| DrawError::ImageDecode {
+                        path: PathBuf::from("animated"),
+                        reason: format!("Failed to prepare animated source: {}", e),
+                    })?;
+
+                let frame = animated_source.next_frame()
+                    .map_err(|e| DrawError::ImageDecode {
+                        path: PathBuf::from("animated"),
+                        reason: format!("Failed to get next frame: {}", e),
+                    })?;
+                video_payload = Some(frame.payload);
+            }
         }
 
         // Now we can get mutable access to the layer
         let layer = self.layers.get_mut(layer_idx).ok_or(DrawError::NoSource)?;
         let pool = layer.pool.as_mut().ok_or(DrawError::NoSource)?;
 
-        let image = cur_resized_img.as_ref().expect("cur_resized_img was just set");
-
-        let buffer = crate::draw::canvas(pool, image, width as i32, height as i32, width as i32 * 4)?;
+        let buffer = if let Some(payload) = video_payload {
+            match payload {
+                FramePayload::Bgrx { data, width: frame_width, height: frame_height, stride } if frame_width == width && frame_height == height && stride >= width as usize * 4 => {
+                        crate::draw::canvas_from_bgrx(pool, &data, frame_width, frame_height, stride)?
+                    }
+                FramePayload::Image(image) => {
+                    crate::draw::canvas(pool, &image, width as i32, height as i32, width as i32 * 4)?
+                }
+                FramePayload::Bgrx { .. } => {
+                    let black = DynamicImage::new_rgba8(width, height);
+                    crate::draw::canvas(pool, &black, width as i32, height as i32, width as i32 * 4)?
+                }
+            }
+        } else {
+            let image = cur_resized_img.as_ref().expect("cur_resized_img was just set");
+            crate::draw::canvas(pool, image, width as i32, height as i32, width as i32 * 4)?
+        };
 
         crate::draw::layer_surface(
             layer,
@@ -276,17 +330,19 @@ impl Wallpaper {
         Ok((width, height))
     }
 
-    fn prepare_scaled_image(&mut self, width: u32, height: u32) -> Result<DynamicImage, DrawError> {
+    fn prepare_scaled_image(&mut self, width: u32, height: u32) -> Result<Arc<DynamicImage>, DrawError> {
         // Clone to avoid borrow conflicts when calling methods that mutate self
         let source = self.current_source.clone().ok_or(DrawError::NoSource)?;
 
         match source {
-            Source::Path(ref path) => self.scale_image_from_path(path, width, height),
+            Source::Path(ref path) => self
+                .scale_image_from_path(path, width, height)
+                .map(Arc::new),
             Source::Color(Color::Single([r, g, b])) => {
-                Ok(self.generate_solid_color([r, g, b], width, height))
+                Ok(Arc::new(self.generate_solid_color([r, g, b], width, height)))
             }
             Source::Color(Color::Gradient(ref gradient)) => {
-                self.generate_gradient(gradient, width, height)
+                self.generate_gradient(gradient, width, height).map(Arc::new)
             }
             Source::Shader(_) | Source::Video(_) | Source::Animated(_) => {
                 // Use persistent animated source
@@ -312,7 +368,13 @@ impl Wallpaper {
                         reason: format!("Failed to get next frame: {}", e),
                     })?;
 
-                Ok(frame.image)
+                match frame.payload {
+                    FramePayload::Image(image) => Ok(image),
+                    FramePayload::Bgrx { .. } => Err(DrawError::ImageDecode {
+                        path: PathBuf::from("animated"),
+                        reason: "Unexpected raw frame payload for image path".to_string(),
+                    }),
+                }
             }
         }
     }
@@ -538,6 +600,12 @@ impl Wallpaper {
         // Remove existing animation timer if present
         if let Some(token) = self.animation_timer_token.take() {
             self.loop_handle.remove(token);
+        }
+
+        // Video playback is paced by Wayland frame callbacks. Timer-driven
+        // redraws can race the compositor cadence and cause visible jitter.
+        if matches!(self.entry.source, Source::Video(_)) {
+            return;
         }
 
         // Get frame duration from the animated source

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -157,6 +157,9 @@ impl Wallpaper {
                 self.loop_handle.remove(token);
             }
             self.animated_source = None;
+            for layer in &mut self.layers {
+                layer.last_video_frame_draw = None;
+            }
             self.load_images();
         }
 
@@ -227,16 +230,51 @@ impl Wallpaper {
             return false;
         }
 
-        let Some(layer) = self
+        let frame_duration = self
+            .animated_source
+            .as_ref()
+            .map(|source| source.frame_duration())
+            .unwrap_or(crate::source::DEFAULT_FRAME_DURATION);
+
+        let Some(layer_idx) = self
             .layers
-            .iter_mut()
-            .find(|layer| layer.layer.wl_surface() == surface)
+            .iter()
+            .position(|layer| layer.layer.wl_surface() == surface)
         else {
             return false;
         };
 
-        layer.needs_redraw = true;
-        self.draw();
+        if self.layers[layer_idx]
+            .last_video_frame_draw
+            .is_some_and(|last_draw| last_draw.elapsed() < frame_duration)
+        {
+            self.layers[layer_idx]
+                .layer
+                .wl_surface()
+                .frame(&self.queue_handle, surface.clone());
+            surface.commit();
+            return true;
+        }
+
+        self.layers[layer_idx].needs_redraw = true;
+
+        match self.draw_layer_by_index(layer_idx, &mut None, Instant::now()) {
+            Ok(()) => {
+                self.layers[layer_idx].last_video_frame_draw = Some(Instant::now());
+            }
+            Err(DrawError::NoSource) => {
+                tracing::info!("No source for wallpaper");
+                self.layers[layer_idx]
+                    .layer
+                    .wl_surface()
+                    .frame(&self.queue_handle, surface.clone());
+                surface.commit();
+            }
+            Err(why) => {
+                tracing::error!(?why, "wallpaper could not be drawn");
+            }
+        }
+
         true
     }
 

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -2,6 +2,7 @@
 
 use crate::{CosmicBg, CosmicBgLayer};
 use crate::animated::AnimatedSource;
+use crate::scaler::FitBlurBgrxWorkspace;
 use crate::shader::ShaderSource;
 use crate::source::{FramePayload, WallpaperSource};
 use crate::video::VideoSource;
@@ -35,6 +36,8 @@ use sctk::{
 use thiserror::Error;
 use tracing::error;
 use walkdir::WalkDir;
+
+const FIT_BLUR_BACKGROUND_REFRESH_FRAMES: u32 = 60;
 
 // TODO filter images by whether they seem to match dark / light mode
 // Alternatively only load from light / dark subdirectories given a directory source when this is active
@@ -70,6 +73,17 @@ pub struct Wallpaper {
     // Filesystem watcher for live wallpaper directory updates.
     // Must be stored here to keep the watcher alive for the lifetime of this wallpaper.
     _watcher: Option<RecommendedWatcher>,
+    fit_blur_background_cache: Vec<FitBlurBackgroundCache>,
+    fit_blur_bgrx_workspace: FitBlurBgrxWorkspace,
+}
+
+struct FitBlurBackgroundCache {
+    layer_width: u32,
+    layer_height: u32,
+    frame_width: u32,
+    frame_height: u32,
+    frames_since_refresh: u32,
+    background: Arc<[u8]>,
 }
 
 impl std::fmt::Debug for Wallpaper {
@@ -83,6 +97,7 @@ impl std::fmt::Debug for Wallpaper {
             .field("timer_token", &self.timer_token)
             .field("animated_source", &self.animated_source.as_ref().map(|s| s.description()))
             .field("animation_timer_token", &self.animation_timer_token)
+            .field("fit_blur_background_cache", &self.fit_blur_background_cache.len())
             .finish_non_exhaustive()
     }
 }
@@ -96,6 +111,25 @@ impl Drop for Wallpaper {
             self.loop_handle.remove(token);
         }
     }
+}
+
+enum PreparedVideoFrame {
+    Bgrx {
+        data: Arc<[u8]>,
+        width: u32,
+        height: u32,
+        stride: usize,
+    },
+    FitBlurBgrx {
+        background: Arc<[u8]>,
+        data: Arc<[u8]>,
+        frame_width: u32,
+        frame_height: u32,
+        frame_stride: usize,
+        layer_width: u32,
+        layer_height: u32,
+    },
+    Image(DynamicImage),
 }
 
 impl Wallpaper {
@@ -115,6 +149,8 @@ impl Wallpaper {
             animated_source: None,
             animation_timer_token: None,
             _watcher: None,
+            fit_blur_background_cache: Vec::new(),
+            fit_blur_bgrx_workspace: FitBlurBgrxWorkspace::default(),
             loop_handle,
             queue_handle,
         };
@@ -152,6 +188,7 @@ impl Wallpaper {
         // If source changed, reload images (this will be called from apply_backgrounds)
         if source_changed {
             self.current_image = None;
+            self.fit_blur_background_cache.clear();
             // Clear animated source and timer
             if let Some(token) = self.animation_timer_token.take() {
                 self.loop_handle.remove(token);
@@ -173,6 +210,7 @@ impl Wallpaper {
 
         // Trigger redraw if scaling mode changed
         if scaling_changed {
+            self.fit_blur_background_cache.clear();
             for layer in &mut self.layers {
                 layer.needs_redraw = true;
             }
@@ -300,40 +338,73 @@ impl Wallpaper {
             }
         }
 
-        let mut video_payload = None;
+        let mut video_frame = None;
         if matches!(self.entry.source, Source::Video(_)) {
             if let Some(animated_source) = self.animated_source.as_mut() {
-                animated_source.prepare(width, height)
-                    .map_err(|e| DrawError::ImageDecode {
-                        path: PathBuf::from("animated"),
-                        reason: format!("Failed to prepare animated source: {}", e),
-                    })?;
+                match &self.entry.scaling_mode {
+                    ScalingMode::Stretch => animated_source.prepare(width, height),
+                    ScalingMode::Fit(_) | ScalingMode::FitBlur | ScalingMode::Zoom => {
+                        animated_source.prepare_unscaled()
+                    }
+                }
+                .map_err(|e| DrawError::ImageDecode {
+                    path: PathBuf::from("animated"),
+                    reason: format!("Failed to prepare animated source: {}", e),
+                })?;
 
                 let frame = animated_source.next_frame()
                     .map_err(|e| DrawError::ImageDecode {
                         path: PathBuf::from("animated"),
                         reason: format!("Failed to get next frame: {}", e),
                     })?;
-                video_payload = Some(frame.payload);
+                video_frame = Some(frame);
             }
         }
+
+        let video_frame = video_frame
+            .map(|frame| {
+                self.prepare_video_frame(frame.payload, frame.is_placeholder, width, height)
+            })
+            .transpose()?;
 
         // Now we can get mutable access to the layer
         let layer = self.layers.get_mut(layer_idx).ok_or(DrawError::NoSource)?;
         let pool = layer.pool.as_mut().ok_or(DrawError::NoSource)?;
 
-        let buffer = if let Some(payload) = video_payload {
-            match payload {
-                FramePayload::Bgrx { data, width: frame_width, height: frame_height, stride } if frame_width == width && frame_height == height && stride >= width as usize * 4 => {
-                        crate::draw::canvas_from_bgrx(pool, &data, frame_width, frame_height, stride)?
-                    }
-                FramePayload::Image(image) => {
-                    crate::draw::canvas(pool, &image, width as i32, height as i32, width as i32 * 4)?
-                }
-                FramePayload::Bgrx { .. } => {
-                    let black = DynamicImage::new_rgba8(width, height);
-                    crate::draw::canvas(pool, &black, width as i32, height as i32, width as i32 * 4)?
-                }
+        let buffer = if let Some(frame) = video_frame {
+            match frame {
+                PreparedVideoFrame::Bgrx {
+                    data,
+                    width,
+                    height,
+                    stride,
+                } => crate::draw::canvas_from_bgrx(pool, &data, width, height, stride)?,
+                PreparedVideoFrame::FitBlurBgrx {
+                    background,
+                    data,
+                    frame_width,
+                    frame_height,
+                    frame_stride,
+                    layer_width,
+                    layer_height,
+                } => crate::draw::canvas_from_fit_blur_bgrx_with_workspace(
+                    pool,
+                    &background,
+                    &data,
+                    frame_width,
+                    frame_height,
+                    frame_stride,
+                    layer_width,
+                    layer_height,
+                    &mut self.fit_blur_bgrx_workspace,
+                )?,
+                PreparedVideoFrame::Image(image) => crate::draw::canvas(
+                    pool,
+                    &image,
+                    width as i32,
+                    height as i32,
+                    width as i32 * 4,
+                )?,
             }
         } else {
             let image = cur_resized_img.as_ref().expect("cur_resized_img was just set");
@@ -451,11 +522,118 @@ impl Wallpaper {
     }
 
     fn apply_scaling_mode(&self, img: &DynamicImage, width: u32, height: u32) -> DynamicImage {
-        match self.entry.scaling_mode {
-            ScalingMode::Fit(color) => crate::scaler::fit(img, &color, width, height),
+        match &self.entry.scaling_mode {
+            ScalingMode::Fit(color) => crate::scaler::fit(img, color, width, height),
+            ScalingMode::FitBlur => crate::scaler::fit_blur(img, width, height),
             ScalingMode::Zoom => crate::scaler::zoom(img, width, height),
             ScalingMode::Stretch => crate::scaler::stretch(img, width, height),
         }
+    }
+
+    fn prepare_video_frame(
+        &mut self,
+        payload: FramePayload,
+        is_placeholder: bool,
+        width: u32,
+        height: u32,
+    ) -> Result<PreparedVideoFrame, DrawError> {
+        match payload {
+            FramePayload::Bgrx {
+                data,
+                width: frame_width,
+                height: frame_height,
+                stride,
+            } => {
+                if matches!(&self.entry.scaling_mode, ScalingMode::Stretch)
+                    && frame_width == width
+                    && frame_height == height
+                    && stride >= width as usize * 4
+                {
+                    return Ok(PreparedVideoFrame::Bgrx {
+                        data,
+                        width: frame_width,
+                        height: frame_height,
+                        stride,
+                    });
+                }
+
+                if matches!(&self.entry.scaling_mode, ScalingMode::FitBlur) {
+                    let background = self.prepare_fit_blur_video_bgrx_frame(
+                        &data,
+                        frame_width,
+                        frame_height,
+                        stride,
+                        is_placeholder,
+                        width,
+                        height,
+                    )?;
+                    return Ok(PreparedVideoFrame::FitBlurBgrx {
+                        background,
+                        data,
+                        frame_width,
+                        frame_height,
+                        frame_stride: stride,
+                        layer_width: width,
+                        layer_height: height,
+                    });
+                }
+
+                let image = bgrx_to_dynamic_image(&data, frame_width, frame_height, stride)?;
+                Ok(PreparedVideoFrame::Image(self.apply_scaling_mode(
+                    &image, width, height,
+                )))
+            }
+            FramePayload::Image(image) => {
+                if matches!(&self.entry.scaling_mode, ScalingMode::FitBlur) {
+                    return Ok(PreparedVideoFrame::Image(
+                        self.prepare_fit_blur_video_frame(&image, is_placeholder, width, height),
+                    ));
+                }
+
+                Ok(PreparedVideoFrame::Image(self.apply_scaling_mode(
+                    &image, width, height,
+                )))
+            }
+        }
+    }
+
+    fn prepare_fit_blur_video_frame(
+        &mut self,
+        image: &DynamicImage,
+        is_placeholder: bool,
+        width: u32,
+        height: u32,
+    ) -> DynamicImage {
+        prepare_fit_blur_video_frame_from_cache(
+            &mut self.fit_blur_background_cache,
+            image,
+            is_placeholder,
+            width,
+            height,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn prepare_fit_blur_video_bgrx_frame(
+        &mut self,
+        data: &[u8],
+        frame_width: u32,
+        frame_height: u32,
+        frame_stride: usize,
+        is_placeholder: bool,
+        width: u32,
+        height: u32,
+    ) -> Result<Arc<[u8]>, DrawError> {
+        prepare_fit_blur_video_bgrx_background_from_cache(
+            &mut self.fit_blur_background_cache,
+            data,
+            frame_width,
+            frame_height,
+            frame_stride,
+            is_placeholder,
+            width,
+            height,
+        )
     }
 
     fn generate_solid_color(&self, color: [f32; 3], width: u32, height: u32) -> DynamicImage {
@@ -740,6 +918,7 @@ impl Wallpaper {
 
     fn clear_image(&mut self) {
         self.current_image = None;
+        self.fit_blur_background_cache.clear();
         for l in &mut self.layers {
             l.needs_redraw = true;
         }
@@ -760,6 +939,272 @@ fn current_image(output: &str) -> Option<Source> {
     };
 
     wallpaper.map(|(_name, path)| path)
+}
+
+fn bgrx_to_dynamic_image(
+    data: &[u8],
+    width: u32,
+    height: u32,
+    stride: usize,
+) -> Result<DynamicImage, DrawError> {
+    let row_bytes = width as usize * 4;
+    if stride < row_bytes || data.len() < stride * height as usize {
+        return Err(DrawError::ImageDecode {
+            path: PathBuf::from("video"),
+            reason: "Invalid BGRx frame dimensions".to_string(),
+        });
+    }
+
+    let mut rgba = vec![0; row_bytes * height as usize];
+    for row in 0..height as usize {
+        let src_start = row * stride;
+        let src_row = &data[src_start..src_start + row_bytes];
+        let dst_start = row * row_bytes;
+        let dst_row = &mut rgba[dst_start..dst_start + row_bytes];
+
+        for (src, dst) in src_row.chunks_exact(4).zip(dst_row.chunks_exact_mut(4)) {
+            let [b, g, r, _x] = src else { unreachable!() };
+            dst.copy_from_slice(&[*r, *g, *b, 255]);
+        }
+    }
+
+    image::ImageBuffer::from_raw(width, height, rgba)
+        .map(DynamicImage::ImageRgba8)
+        .ok_or_else(|| DrawError::ImageDecode {
+            path: PathBuf::from("video"),
+            reason: "Failed to build image from BGRx frame".to_string(),
+        })
+}
+
+fn prepare_fit_blur_video_frame_from_cache(
+    fit_blur_background_cache: &mut Vec<FitBlurBackgroundCache>,
+    image: &DynamicImage,
+    is_placeholder: bool,
+    width: u32,
+    height: u32,
+) -> DynamicImage {
+    if is_placeholder {
+        let background = crate::scaler::fit_blur_background_fast(image, width, height);
+        return crate::scaler::compose_fit_blur(image, &background, width, height);
+    }
+
+    let background = fit_blur_background_from_cache(
+        fit_blur_background_cache,
+        image,
+        width,
+        height,
+    );
+    let background = bgrx_to_rgba_image(background, width, height)
+        .expect("cached fit-blur background dimensions are valid");
+    crate::scaler::compose_fit_blur(image, &background, width, height)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_fit_blur_video_bgrx_background_from_cache(
+    fit_blur_background_cache: &mut Vec<FitBlurBackgroundCache>,
+    data: &[u8],
+    frame_width: u32,
+    frame_height: u32,
+    frame_stride: usize,
+    is_placeholder: bool,
+    width: u32,
+    height: u32,
+) -> Result<Arc<[u8]>, DrawError> {
+    let row_bytes = frame_width as usize * 4;
+    if frame_stride < row_bytes || data.len() < frame_stride * frame_height as usize {
+        return Err(DrawError::ImageDecode {
+            path: PathBuf::from("video"),
+            reason: "Invalid BGRx frame dimensions".to_string(),
+        });
+    }
+
+    let frame_identity = (frame_width, frame_height);
+    if is_placeholder {
+        let image = bgrx_to_dynamic_image(data, frame_width, frame_height, frame_stride)?;
+        return Ok(fit_blur_background_bgrx_from_image(&image, width, height));
+    }
+
+    if let Some(index) = fit_blur_background_cache.iter().position(|cache| {
+        cache.layer_width == width
+            && cache.layer_height == height
+            && cache.frame_width == frame_identity.0
+            && cache.frame_height == frame_identity.1
+    }) {
+        let cache = &mut fit_blur_background_cache[index];
+        cache.frames_since_refresh += 1;
+        if cache.frames_since_refresh >= FIT_BLUR_BACKGROUND_REFRESH_FRAMES {
+            let image = bgrx_to_dynamic_image(data, frame_width, frame_height, frame_stride)?;
+            cache.background = fit_blur_background_bgrx_from_image(&image, width, height);
+            cache.frames_since_refresh = 0;
+        }
+        return Ok(Arc::clone(&fit_blur_background_cache[index].background));
+    }
+
+    let image = bgrx_to_dynamic_image(data, frame_width, frame_height, frame_stride)?;
+    fit_blur_background_cache.push(FitBlurBackgroundCache {
+        layer_width: width,
+        layer_height: height,
+        frame_width,
+        frame_height,
+        frames_since_refresh: 0,
+        background: fit_blur_background_bgrx_from_image(&image, width, height),
+    });
+
+    Ok(Arc::clone(
+        &fit_blur_background_cache
+            .last()
+            .expect("fit_blur_background_cache was just pushed")
+            .background,
+    ))
+}
+
+fn fit_blur_background_from_cache<'a>(
+    fit_blur_background_cache: &'a mut Vec<FitBlurBackgroundCache>,
+    image: &DynamicImage,
+    width: u32,
+    height: u32,
+) -> &'a [u8] {
+    let frame_width = image.width();
+    let frame_height = image.height();
+
+    if let Some(index) = fit_blur_background_cache.iter().position(|cache| {
+        cache.layer_width == width
+            && cache.layer_height == height
+            && cache.frame_width == frame_width
+            && cache.frame_height == frame_height
+    }) {
+        let cache = &mut fit_blur_background_cache[index];
+        cache.frames_since_refresh += 1;
+        if cache.frames_since_refresh >= FIT_BLUR_BACKGROUND_REFRESH_FRAMES {
+            cache.background = fit_blur_background_bgrx_from_image(image, width, height);
+            cache.frames_since_refresh = 0;
+        }
+        return &fit_blur_background_cache[index].background;
+    }
+
+    fit_blur_background_cache.push(FitBlurBackgroundCache {
+        layer_width: width,
+        layer_height: height,
+        frame_width,
+        frame_height,
+        frames_since_refresh: 0,
+        background: fit_blur_background_bgrx_from_image(image, width, height),
+    });
+
+    &fit_blur_background_cache
+        .last()
+        .expect("fit_blur_background_cache was just pushed")
+        .background
+}
+
+fn fit_blur_background_bgrx_from_image(image: &DynamicImage, width: u32, height: u32) -> Arc<[u8]> {
+    let background = crate::scaler::fit_blur_background_fast(image, width, height);
+    crate::scaler::fit_blur_background_to_bgrx(&background)
+}
+
+fn bgrx_to_rgba_image(data: &[u8], width: u32, height: u32) -> Option<image::RgbaImage> {
+    let row_bytes = width as usize * 4;
+    if data.len() < row_bytes * height as usize {
+        return None;
+    }
+
+    let mut rgba = Vec::with_capacity(row_bytes * height as usize);
+    for pixel in data[..row_bytes * height as usize].chunks_exact(4) {
+        let [b, g, r, _x] = pixel else { unreachable!() };
+        rgba.extend_from_slice(&[*r, *g, *b, 255]);
+    }
+
+    image::ImageBuffer::from_raw(width, height, rgba)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{ImageBuffer, Rgba};
+
+    #[test]
+    fn fit_blur_placeholder_frame_does_not_populate_background_cache() {
+        let mut cache = Vec::new();
+        let placeholder = DynamicImage::ImageRgba8(ImageBuffer::from_pixel(
+            320,
+            180,
+            Rgba([0, 0, 0, 255]),
+        ));
+        let real_frame = DynamicImage::ImageRgba8(ImageBuffer::from_pixel(
+            320,
+            180,
+            Rgba([255, 0, 0, 255]),
+        ));
+
+        let _ = prepare_fit_blur_video_frame_from_cache(
+            &mut cache,
+            &placeholder,
+            true,
+            800,
+            600,
+        );
+        assert!(cache.is_empty());
+
+        let _ = prepare_fit_blur_video_frame_from_cache(
+            &mut cache,
+            &real_frame,
+            false,
+            800,
+            600,
+        );
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn fit_blur_real_frame_refreshes_cached_background_periodically() {
+        let mut cache = Vec::new();
+        let red_frame = DynamicImage::ImageRgba8(ImageBuffer::from_pixel(
+            320,
+            180,
+            Rgba([255, 0, 0, 255]),
+        ));
+        let blue_frame = DynamicImage::ImageRgba8(ImageBuffer::from_pixel(
+            320,
+            180,
+            Rgba([0, 0, 255, 255]),
+        ));
+
+        let first = prepare_fit_blur_video_frame_from_cache(
+            &mut cache,
+            &red_frame,
+            false,
+            800,
+            600,
+        )
+        .to_rgba8();
+        assert_eq!(first.get_pixel(400, 10).0, [255, 0, 0, 255]);
+
+        let stale_background = prepare_fit_blur_video_frame_from_cache(
+            &mut cache,
+            &blue_frame,
+            false,
+            800,
+            600,
+        )
+        .to_rgba8();
+        assert_eq!(stale_background.get_pixel(400, 10).0, [255, 0, 0, 255]);
+        assert_eq!(stale_background.get_pixel(400, 300).0, [0, 0, 255, 255]);
+
+        let mut refreshed_background = stale_background;
+        for _ in 1..FIT_BLUR_BACKGROUND_REFRESH_FRAMES {
+            refreshed_background = prepare_fit_blur_video_frame_from_cache(
+                &mut cache,
+                &blue_frame,
+                false,
+                800,
+                600,
+            )
+            .to_rgba8();
+        }
+
+        assert_eq!(refreshed_background.get_pixel(400, 10).0, [0, 0, 255, 255]);
+        assert_eq!(cache.len(), 1);
+    }
 }
 
 /// Decodes JPEG XL image files into `image::DynamicImage` via `jxl-oxide`.


### PR DESCRIPTION
## Summary
This PR improves video wallpaper playback by reducing per-frame CPU work and making frame delivery compositor-driven. 

In my setup, video wallpapers were playable at 30 FPS, but 60 FPS showed a periodic stutter. While investigating, I also found that the current hardware acceleration detection was not reliably selecting GPU decode on my system: modern GStreamer setups may expose VA-API/NVDEC decoders as codec-specific elements, while the existing logic expected older generic decoder bins.

Because hardware decode could not be relied on as the only fix, this PR optimizes the CPU/wl_shm path instead.

## What changed
- Use `decodebin` and detect hardware decoder availability for diagnostics instead of forcing a specific decoder bin.
- Pace video redraws from Wayland compositor frame callbacks.
- Avoid timer-driven video redraws that can race compositor cadence.
- Keep only the latest GStreamer frame with `appsink max-buffers=1` and `drop=true`.
- Pull frames on demand from `appsink` instead of copying frames continuously from a callback.
- Request `BGRx` video frames and copy compatible frames directly into `wl_shm` `Xrgb8888` buffers.
- Keep an `Arc<DynamicImage>` fallback path for static images, shaders, animations, and incompatible video frame geometry.
- 
## Why
The previous path did several expensive operations per frame:
```text
GStreamer RGBA buffer
→ copy into Vec
→ wrap as DynamicImage
→ convert/repack RGBA into Xrgb8888
→ upload full wl_shm frame
At 60 FPS, especially on high-resolution displays, that extra conversion and copy pressure can cause visible stutter.
This change removes the RGBA repack step for matching video frames:
GStreamer BGRx buffer
→ direct copy into wl_shm Xrgb8888 buffer
It does not make video fully zero-copy, but it reduces CPU overhead while keeping the existing wl_shm architecture.
Test plan
- cargo check --all-features
- Manual test with video wallpaper at 30 FPS
- Manual test with video wallpaper at 60 FPS
- Verified static/image fallback path remains available
Notes
This improves the current wl_shm-based path, but 60 FPS video wallpapers may still be limited by full-frame wl_shm uploads. A future larger improvement would likely require dmabuf/zero-copy support.